### PR TITLE
Allow full guidewire insertion

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -197,7 +197,8 @@ window.addEventListener('keyup', e => {
 });
 
 let tailProgress = 0;
-const maxInsert = vessel.left.length - 40; // keep some wire outside
+// allow inserting the full wire length while keeping a small portion outside
+const maxInsert = segmentLength * (nodeCount - 1) - 40;
 
 function step() {
     const tail = nodes[nodes.length - 1];


### PR DESCRIPTION
## Summary
- Allow guidewire to advance into the main vessel by basing max insertion on wire length

## Testing
- `node --check simulator.js`


------
https://chatgpt.com/codex/tasks/task_e_68acebb755d8832e8477c29abbc707fd