### PR TITLE
Nudge guidewire tip to enter vessel when advancing

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -199,6 +199,14 @@ class Wire {
         tail.vx = (tail.x - oldx) / dt;
         tail.vy = (tail.y - oldy) / dt;
         tail.vz = (tail.z - oldz) / dt;
+
+        // when advancing, nudge the tip forward so it immediately begins
+        // sliding into the vessel instead of hesitating at the sheath entry
+        if (advance > 0) {
+            const tip = this.nodes[0];
+            tip.vx += this.dir.x * 50 * dt;
+            tip.vy += this.dir.y * 50 * dt;
+        }
     }
 
     integrate(dt) {


### PR DESCRIPTION
## Summary
- Impart a forward impulse to the guidewire tip when advancing so it immediately begins sliding into the vessel

## Testing
- `node --check simulator.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad72403cf4832e8c4d71433078dea0