### PR TITLE
feat: procedural 3d vessel with wireframe toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,12 @@
     <label>C-arm angle
         <input id="carm" type="range" min="-90" max="90" step="1" value="0">
     </label>
+    <label>Wireframe
+        <input id="wireframe" type="checkbox">
+    </label>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.160.0/examples/js/utils/BufferGeometryUtils.js"></script>
 <script src="simulator.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restore guidewire physics while generating procedural 3D vessel with tapered branches
- expose wire stiffness, C-arm angle, and wireframe toggle controls in UI
- render guidewire as dynamic 3D line driven by mass-spring engine
- weld bifurcation vertices so lumen transitions smoothly from main vessel into two branches

## Testing
- `node -v`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ada98c6734832e85d43e08258943d7