### PR TITLE
Fix BufferGeometryUtils import for three.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,8 +41,12 @@
         <input id="wireframe" type="checkbox">
     </label>
 </div>
-<script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/three@0.160.0/examples/js/utils/BufferGeometryUtils.js"></script>
-<script src="simulator.js"></script>
+<script type="module">
+    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
+    import {BufferGeometryUtils} from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/utils/BufferGeometryUtils.js';
+    window.THREE = THREE;
+    THREE.BufferGeometryUtils = BufferGeometryUtils;
+    import './simulator.js';
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load three.js and BufferGeometryUtils as ES modules and expose them globally

## Testing
- `node -c simulator.js`

------
https://chatgpt.com/codex/tasks/task_e_68adb23e20ec832e8665a03ae83fec02