### PR TITLE
Add import map to resolve three.js module

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,8 +41,15 @@
         <input id="wireframe" type="checkbox">
     </label>
 </div>
+<script type="importmap">
+{
+    "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js"
+    }
+}
+</script>
 <script type="module">
-    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js';
+    import * as THREE from 'three';
     import {BufferGeometryUtils} from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/utils/BufferGeometryUtils.js';
     window.THREE = THREE;
     THREE.BufferGeometryUtils = BufferGeometryUtils;


### PR DESCRIPTION
## Summary
- fix `three` module specifier by adding import map and using bare imports

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adb34591bc832e8e29e91b60261c4b