### PR TITLE
Fix BufferGeometryUtils import

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
 </script>
 <script type="module">
     import * as THREE from 'three';
-    import {BufferGeometryUtils} from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/utils/BufferGeometryUtils.js';
+    import * as BufferGeometryUtils from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/utils/BufferGeometryUtils.js';
     window.THREE = THREE;
     THREE.BufferGeometryUtils = BufferGeometryUtils;
     import './simulator.js';


### PR DESCRIPTION
## Summary
- correct BufferGeometryUtils import to use namespace pattern

## Testing
- `node --check simulator.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adb40a8394832e90a2d9230d8090f7