### PR TITLE
Fix THREE reference error by using direct module imports

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,12 +48,6 @@
     }
 }
 </script>
-<script type="module">
-    import * as THREE from 'three';
-    import * as BufferGeometryUtils from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/utils/BufferGeometryUtils.js';
-    window.THREE = THREE;
-    THREE.BufferGeometryUtils = BufferGeometryUtils;
-    import './simulator.js';
-</script>
+<script type="module" src="./simulator.js"></script>
 </body>
 </html>

--- a/simulator.js
+++ b/simulator.js
@@ -1,3 +1,6 @@
+import * as THREE from 'three';
+import { mergeBufferGeometries, mergeVertices } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/utils/BufferGeometryUtils.js';
+
 const canvas = document.getElementById('sim');
 const renderer = new THREE.WebGLRenderer({canvas, antialias: true});
 renderer.setSize(window.innerWidth, window.innerHeight);
@@ -120,8 +123,8 @@ function generateVessel() {
     );
     const leftGeom = createTaperedTube(leftCurve, 64, 16, mainRadius, branchRadius);
 
-    let merged = THREE.BufferGeometryUtils.mergeBufferGeometries([trunkGeom, rightGeom, leftGeom], true);
-    merged = THREE.BufferGeometryUtils.mergeVertices(merged);
+    let merged = mergeBufferGeometries([trunkGeom, rightGeom, leftGeom], true);
+    merged = mergeVertices(merged);
     const vesselMesh = new THREE.Mesh(merged, vesselMaterial);
     vesselGroup.add(vesselMesh);
 


### PR DESCRIPTION
## Summary
- Import Three.js and BufferGeometryUtils directly within `simulator.js`
- Update script loading in `index.html` to rely on ES modules

## Testing
- `node --check simulator.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68addb90223c832e800eba74328a09f9