### PR TITLE
fix: map three-mesh-bvh module

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,8 @@
 <script type="importmap">
 {
     "imports": {
-        "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js"
+        "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
+        "three-mesh-bvh": "https://cdn.jsdelivr.net/npm/three-mesh-bvh@0.7.5/build/index.module.js"
     }
 }
 </script>


### PR DESCRIPTION
## Summary
- add import map entry for `three-mesh-bvh`

## Testing
- `node --check simulator.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68ade34a738c832e979e0d3f7edaa819