### PR TITLE
Add PBD bending constraint and smoothing

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
 <body>
 <canvas id="sim"></canvas>
 <div id="controls">
-    <label>Wire stiffness
+    <label>Bending stiffness
         <input id="stiffness" type="range" min="0" max="2" step="0.1" value="1.5">
     </label>
     <label>C-arm yaw

--- a/simulator.js
+++ b/simulator.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { Brush, Evaluator, ADDITION } from 'https://unpkg.com/three-bvh-csg@0.0.17/build/index.module.js';
-import { Guidewire, setWireStiffness } from './physics/guidewire.js';
+import { Guidewire, setBendingStiffness } from './physics/guidewire.js';
 
 const canvas = document.getElementById('sim');
 const renderer = new THREE.WebGLRenderer({canvas, antialias: true});
@@ -225,7 +225,7 @@ window.addEventListener('keyup', e => {
     }
 });
 
-const stiffnessSlider = document.getElementById('stiffness');
+const bendSlider = document.getElementById('stiffness');
 const carmYawSlider = document.getElementById('carmYaw');
 const carmPitchSlider = document.getElementById('carmPitch');
 const carmRollSlider = document.getElementById('carmRoll');
@@ -234,11 +234,11 @@ const carmYSlider = document.getElementById('carmY');
 const carmZSlider = document.getElementById('carmZ');
 const wireframeToggle = document.getElementById('wireframe');
 
-let wireStiffness = parseFloat(stiffnessSlider.value);
-setWireStiffness(wireStiffness);
-stiffnessSlider.addEventListener('input', e => {
-    wireStiffness = parseFloat(e.target.value);
-    setWireStiffness(wireStiffness);
+let bendingStiffness = parseFloat(bendSlider.value);
+setBendingStiffness(bendingStiffness);
+bendSlider.addEventListener('input', e => {
+    bendingStiffness = parseFloat(e.target.value);
+    setBendingStiffness(bendingStiffness);
 });
 
 let carmYaw = 0;


### PR DESCRIPTION
## Summary
- Introduce adjustable bending stiffness parameter and apply angular PBD constraint for guidewire nodes.
- Add Laplacian smoothing pass after constraint solving to reduce sharp kinks.
- Expose bending stiffness via UI slider.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check physics/guidewire.js simulator.js index.html`


------
https://chatgpt.com/codex/tasks/task_e_68adf6168e84832e9ef61cc080d11ffd