### PR TITLE
Add configurable wall friction and damping

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,15 @@
     <label>Bending stiffness
         <input id="stiffness" type="range" min="0" max="2" step="0.1" value="1.5">
     </label>
+    <label>Static friction
+        <input id="staticFriction" type="range" min="0" max="1" step="0.01" value="0.05">
+    </label>
+    <label>Kinetic friction
+        <input id="kineticFriction" type="range" min="0" max="1" step="0.01" value="0.02">
+    </label>
+    <label>Normal damping
+        <input id="normalDamping" type="range" min="0" max="1" step="0.01" value="0.5">
+    </label>
     <label>C-arm yaw
         <input id="carmYaw" type="range" min="-180" max="180" step="1" value="0">
     </label>

--- a/simulator.js
+++ b/simulator.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { Brush, Evaluator, ADDITION } from 'https://unpkg.com/three-bvh-csg@0.0.17/build/index.module.js';
-import { Guidewire, setBendingStiffness } from './physics/guidewire.js';
+import { Guidewire, setBendingStiffness, setWallFriction, setNormalDamping } from './physics/guidewire.js';
 
 const canvas = document.getElementById('sim');
 const renderer = new THREE.WebGLRenderer({canvas, antialias: true});
@@ -226,6 +226,9 @@ window.addEventListener('keyup', e => {
 });
 
 const bendSlider = document.getElementById('stiffness');
+const staticFricSlider = document.getElementById('staticFriction');
+const kineticFricSlider = document.getElementById('kineticFriction');
+const dampingSlider = document.getElementById('normalDamping');
 const carmYawSlider = document.getElementById('carmYaw');
 const carmPitchSlider = document.getElementById('carmPitch');
 const carmRollSlider = document.getElementById('carmRoll');
@@ -239,6 +242,24 @@ setBendingStiffness(bendingStiffness);
 bendSlider.addEventListener('input', e => {
     bendingStiffness = parseFloat(e.target.value);
     setBendingStiffness(bendingStiffness);
+});
+
+let staticFriction = parseFloat(staticFricSlider.value);
+let kineticFriction = parseFloat(kineticFricSlider.value);
+let normalDamping = parseFloat(dampingSlider.value);
+setWallFriction(staticFriction, kineticFriction);
+setNormalDamping(normalDamping);
+staticFricSlider.addEventListener('input', e => {
+    staticFriction = parseFloat(e.target.value);
+    setWallFriction(staticFriction, kineticFriction);
+});
+kineticFricSlider.addEventListener('input', e => {
+    kineticFriction = parseFloat(e.target.value);
+    setWallFriction(staticFriction, kineticFriction);
+});
+dampingSlider.addEventListener('input', e => {
+    normalDamping = parseFloat(e.target.value);
+    setNormalDamping(normalDamping);
 });
 
 let carmYaw = 0;


### PR DESCRIPTION
## Summary
- add static and kinetic wall friction coefficients with normal velocity damping
- expose friction and damping controls via new UI sliders

## Testing
- `node --check physics/guidewire.js && echo "physics ok"`
- `node --check simulator.js && echo "sim ok"`


------
https://chatgpt.com/codex/tasks/task_e_68adf87ea398832ebbf9dc90ed0f55bc