### PR TITLE
Adjust camera distance and default C-arm Y offset

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
         <input id="carmX" type="range" min="-200" max="200" step="1" value="0">
     </label>
     <label>C-arm Y
-        <input id="carmY" type="range" min="-200" max="200" step="1" value="0">
+        <input id="carmY" type="range" min="-200" max="200" step="1" value="-60">
     </label>
     <label>C-arm Z
         <input id="carmZ" type="range" min="-200" max="200" step="1" value="0">

--- a/simulator.js
+++ b/simulator.js
@@ -9,7 +9,7 @@ renderer.setSize(window.innerWidth, window.innerHeight);
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x000000);
 
-const cameraRadius = 200;
+const cameraRadius = 350;
 const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 1000);
 camera.position.set(0, 80, cameraRadius);
 scene.add(camera);
@@ -266,7 +266,7 @@ let carmYaw = 0;
 let carmPitch = 0;
 let carmRoll = 0;
 let carmX = 0;
-let carmY = 0;
+let carmY = -60;
 let carmZ = 0;
 
 function getPivotPoint() {


### PR DESCRIPTION
## Summary
- Increase camera radius so the view starts farther back
- Offset C-arm Y axis to place pivot lower and update UI defaults

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -I http://localhost:8000/index.html`


------
https://chatgpt.com/codex/tasks/task_e_68adff1845e4832eaea6178e8b060d5d