### PR TITLE
Expose initial guidewire length configuration

### DIFF
--- a/physics/guidewire.js
+++ b/physics/guidewire.js
@@ -102,7 +102,17 @@ export function setLengthTolerance(value) {
 }
 
 export class Guidewire {
-    constructor(segLen, count, start, dir, vessel, iterations = pbdIterations, tolerance = lengthTolerance, initialInsert = segLen * 5) {
+    constructor(
+        segLen,
+        count,
+        start,
+        dir,
+        vessel,
+        initialLength = segLen * (count - 1),
+        iterations = pbdIterations,
+        tolerance = lengthTolerance,
+        initialInsert = 0
+    ) {
         this.segmentLength = segLen;
         this.tailStart = start;
         this.dir = dir;
@@ -112,13 +122,13 @@ export class Guidewire {
         this.nodes = [];
         this.tailProgress = initialInsert;
         for (let i = 0; i < count; i++) {
-            const t = this.tailProgress + segLen * (count - 1 - i);
+            const t = this.tailProgress + initialLength - segLen * i;
             const x = start.x + dir.x * t;
             const y = start.y + dir.y * t;
             const z = start.z + dir.z * t;
             this.nodes.push({x, y, z, vx: 0, vy: 0, vz: 0, fx: 0, fy: 0, fz: 0, oldx: x, oldy: y, oldz: z});
         }
-        this.maxInsert = this.tailProgress + segLen * (count - 1);
+        this.maxInsert = this.tailProgress + initialLength;
         this.solvePbd();
     }
 

--- a/simulator.js
+++ b/simulator.js
@@ -191,6 +191,7 @@ const vessel = generateVessel();
 
 const segmentLength = 12;
 const nodeCount = 80;
+const initialWireLength = segmentLength;
 
 const leftDir = {
     x: (vessel.branchPoint.x - vessel.left.end.x) / vessel.left.length,
@@ -205,7 +206,7 @@ const tailStart = {
 };
 
 
-const wire = new Guidewire(segmentLength, nodeCount, tailStart, leftDir, vessel);
+const wire = new Guidewire(segmentLength, nodeCount, tailStart, leftDir, vessel, initialWireLength);
 
 let advance = 0;
 window.addEventListener('keydown', e => {


### PR DESCRIPTION
## Summary
- Allow specifying the starting length of a guidewire
- Default guidewire insertion to 0 and compute nodes from provided initial length
- Pass initial length from the simulator via configurable constant

## Testing
- `node --check physics/guidewire.js`
- `node --check simulator.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae04742ca4832eba41f20f8e78bc86