### PR TITLE
feat: add velocity damping and guidewire tuning

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,13 +35,16 @@
         <input id="stiffness" type="range" min="0" max="2" step="0.1" value="1.5">
     </label>
     <label>Static friction
-        <input id="staticFriction" type="range" min="0" max="1" step="0.01" value="0.05">
+        <input id="staticFriction" type="range" min="0" max="1" step="0.01" value="0.2">
     </label>
     <label>Kinetic friction
-        <input id="kineticFriction" type="range" min="0" max="1" step="0.01" value="0.02">
+        <input id="kineticFriction" type="range" min="0" max="1" step="0.01" value="0.1">
     </label>
     <label>Normal damping
         <input id="normalDamping" type="range" min="0" max="1" step="0.01" value="0.5">
+    </label>
+    <label>Velocity damping
+        <input id="velocityDamping" type="range" min="0" max="1" step="0.01" value="0.98">
     </label>
     <label>C-arm yaw
         <input id="carmYaw" type="range" min="-180" max="180" step="1" value="0">

--- a/physics/guidewire.js
+++ b/physics/guidewire.js
@@ -1,7 +1,13 @@
 // Wall interaction parameters with defaults
-let wallStaticFriction = 0.05;
-let wallKineticFriction = 0.02;
+let wallStaticFriction = 0.2;
+let wallKineticFriction = 0.1;
 let wallNormalDamping = 0.5;
+
+// Force applied to the tip when advancing the tail
+let advanceForce = 100;
+
+// Global velocity damping applied each integrate step
+let velocityDamping = 0.98;
 
 // Allow configuration from the outside
 export function setWallFriction(staticCoeff, kineticCoeff) {
@@ -11,6 +17,14 @@ export function setWallFriction(staticCoeff, kineticCoeff) {
 
 export function setNormalDamping(value) {
     wallNormalDamping = value;
+}
+
+export function setAdvanceForce(value) {
+    advanceForce = value;
+}
+
+export function setVelocityDamping(value) {
+    velocityDamping = value;
 }
 
 function clamp(v, min, max) {
@@ -131,9 +145,9 @@ export class Guidewire {
         tail.vx = tail.vy = tail.vz = 0;
         if (advance > 0) {
             const tip = this.nodes[0];
-            tip.fx += this.dir.x * 500;
-            tip.fy += this.dir.y * 500;
-            tip.fz += this.dir.z * 500;
+            tip.fx += this.dir.x * advanceForce;
+            tip.fy += this.dir.y * advanceForce;
+            tip.fz += this.dir.z * advanceForce;
         }
     }
 
@@ -178,6 +192,9 @@ export class Guidewire {
             n.x += n.vx * dt;
             n.y += n.vy * dt;
             n.z += n.vz * dt;
+            n.vx *= velocityDamping;
+            n.vy *= velocityDamping;
+            n.vz *= velocityDamping;
         }
     }
 

--- a/simulator.js
+++ b/simulator.js
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import { Brush, Evaluator, ADDITION } from 'https://unpkg.com/three-bvh-csg@0.0.17/build/index.module.js';
-import { Guidewire, setBendingStiffness, setWallFriction, setNormalDamping } from './physics/guidewire.js';
+import { Guidewire, setBendingStiffness, setWallFriction, setNormalDamping, setVelocityDamping } from './physics/guidewire.js';
 
 const canvas = document.getElementById('sim');
 const renderer = new THREE.WebGLRenderer({canvas, antialias: true});
@@ -229,6 +229,7 @@ const bendSlider = document.getElementById('stiffness');
 const staticFricSlider = document.getElementById('staticFriction');
 const kineticFricSlider = document.getElementById('kineticFriction');
 const dampingSlider = document.getElementById('normalDamping');
+const velDampingSlider = document.getElementById('velocityDamping');
 const carmYawSlider = document.getElementById('carmYaw');
 const carmPitchSlider = document.getElementById('carmPitch');
 const carmRollSlider = document.getElementById('carmRoll');
@@ -247,8 +248,10 @@ bendSlider.addEventListener('input', e => {
 let staticFriction = parseFloat(staticFricSlider.value);
 let kineticFriction = parseFloat(kineticFricSlider.value);
 let normalDamping = parseFloat(dampingSlider.value);
+let velocityDamping = parseFloat(velDampingSlider.value);
 setWallFriction(staticFriction, kineticFriction);
 setNormalDamping(normalDamping);
+setVelocityDamping(velocityDamping);
 staticFricSlider.addEventListener('input', e => {
     staticFriction = parseFloat(e.target.value);
     setWallFriction(staticFriction, kineticFriction);
@@ -260,6 +263,10 @@ kineticFricSlider.addEventListener('input', e => {
 dampingSlider.addEventListener('input', e => {
     normalDamping = parseFloat(e.target.value);
     setNormalDamping(normalDamping);
+});
+velDampingSlider.addEventListener('input', e => {
+    velocityDamping = parseFloat(e.target.value);
+    setVelocityDamping(velocityDamping);
 });
 
 let carmYaw = 0;


### PR DESCRIPTION
## Summary
- make guidewire advancement force configurable and reduce default
- add global velocity damping with UI control
- raise default vessel wall friction

## Testing
- `node --check physics/guidewire.js`
- `node --check simulator.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae048018bc832eac84357fb9ac280a