### PR TITLE
Stabilize physics timestep in simulator

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -336,10 +336,22 @@ function updateWireMesh() {
 }
 
 let lastTime = performance.now();
+const fixedDt = 1 / 60;
+let accumulator = 0;
+// Maximum physics steps per frame; adjust for browser performance.
+let maxSubSteps = 5;
+
 function animate(time) {
     const dt = (time - lastTime) / 1000;
     lastTime = time;
-    wire.step(dt, advance);
+
+    // Accumulate time and step the physics at a fixed rate.
+    accumulator += Math.min(dt, fixedDt * maxSubSteps);
+    while (accumulator >= fixedDt) {
+        wire.step(fixedDt, advance);
+        accumulator -= fixedDt;
+    }
+
     updateWireMesh();
     renderer.render(scene, camera);
     requestAnimationFrame(animate);


### PR DESCRIPTION
## Summary
- Integrate guidewire physics using a fixed 1/60 s timestep
- Accumulate elapsed time and run multiple substeps when needed
- Allow tuning max substeps per frame for different browser performance

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check simulator.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae0481aee0832e8a909236f9a5cae5