### PR TITLE
Add min insert clamping to guidewire tail advancement

### DIFF
--- a/physics/guidewire.js
+++ b/physics/guidewire.js
@@ -143,11 +143,16 @@ export class Guidewire {
             this.nodes.push({x, y, z, vx: 0, vy: 0, vz: 0, fx: 0, fy: 0, fz: 0, oldx: x, oldy: y, oldz: z});
         }
         this.maxInsert = this.tailProgress + initialLength;
+        this.minInsert = Math.min(this.tailProgress - initialLength, 0);
         this.solvePbd();
     }
 
     advanceTail(advance, dt) {
-        this.tailProgress = clamp(this.tailProgress + advance * 40 * dt, 0, this.maxInsert);
+        this.tailProgress = clamp(
+            this.tailProgress + advance * 40 * dt,
+            this.minInsert,
+            this.maxInsert
+        );
         const tail = this.nodes[this.nodes.length - 1];
         tail.x = this.tailStart.x + this.dir.x * this.tailProgress;
         tail.y = this.tailStart.y + this.dir.y * this.tailProgress;


### PR DESCRIPTION
## Summary
- Track minimum insertion length for guidewire and clamp tail progress between minimum and maximum insert
- Allow tail retraction without exceeding initial starting position

## Testing
- `node --check physics/guidewire.js` *(fails: Unexpected token 'export')*
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68ae0e3c0f18832eb5f7a207d1fb5537