### PR TITLE
Allow guidewire exit via open vessel ends

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -45,7 +45,7 @@ const tailStart = {
 }; // start outside so the tip begins `initialInsert` inside the vessel
 
 
-const wire = new Guidewire(segmentLength, nodeCount, tailStart, leftDir, vessel, initialWireLength, undefined, undefined, initialInsert);
+const wire = new Guidewire(segmentLength, nodeCount, tailStart, leftDir, vessel, initialWireLength, undefined, undefined, initialInsert, { left: true });
 
 let advance = 0;
 window.addEventListener('keydown', e => {


### PR DESCRIPTION
## Summary
- Detect when nodes move beyond designated vessel ends and skip clamping
- Add optional `openEnds` parameter to guidewire physics and simulator
- Permit guidewire retraction through an open branch without wall interference

## Testing
- `node --experimental-modules testOpenEnd.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68ae120b482c832eb358b59606909cc0