### PR TITLE
Display inserted wire length indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
 <body>
 <canvas id="sim"></canvas>
 <div id="controls">
+    <div id="insertedLength">0 cm</div>
     <label>Bending stiffness
         <input id="stiffness" type="range" min="0" max="2" step="0.1" value="1.5">
     </label>

--- a/simulator.js
+++ b/simulator.js
@@ -77,6 +77,7 @@ const carmXSlider = document.getElementById('carmX');
 const carmYSlider = document.getElementById('carmY');
 const carmZSlider = document.getElementById('carmZ');
 const wireframeToggle = document.getElementById('wireframe');
+const insertedLength = document.getElementById('insertedLength');
 
 const sliders = [
     bendSlider,
@@ -212,6 +213,8 @@ function animate(time) {
     while (accumulator >= fixedDt) {
         wire.step(fixedDt, advance);
         accumulator -= fixedDt;
+        const inserted = Math.max(0, wire.tailProgress);
+        insertedLength.textContent = (inserted / 10).toFixed(1) + ' cm';
     }
 
     updateWireMesh();


### PR DESCRIPTION
## Summary
- Show current inserted wire length in controls UI.
- Update simulator to calculate tail progress and refresh the indicator each frame.

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae13d05544832eb8d9752ee71d7ba5