### PR TITLE
Tilt introducer sheath 30° anterior

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This prototype demonstrates a basic browser-based simulator for guiding a stiff 
 
 ## Usage
 
-Open `index.html` in a modern browser. Use `W`/`S` or the up/down arrow keys to advance or retract the guidewire through the introducer sheath positioned in the left branch. The push distance now allows the wire to be fully inserted if desired.
+Open `index.html` in a modern browser. Use `W`/`S` or the up/down arrow keys to advance or retract the guidewire through the introducer sheath positioned in the left branch. The sheath exits this branch with a fixed 30° anterior (+Z) angulation, and the push distance now allows the wire to be fully inserted if desired.
 
 ## Vessel Geometry
 
-The vessel is generated deterministically. Branch length and angle offset use fixed defaults (140 units and 0 radians) and only change when explicitly provided to `generateVessel`.
+The vessel is generated deterministically. Branch length and angle offset use fixed defaults (140 units and 0 radians) and only change when explicitly provided to `generateVessel`. The introducer sheath extends from the left branch with a 30° anterior (+Z) tilt.


### PR DESCRIPTION
## Summary
- Tilt left-branch sheath 30° toward +Z using quaternion rotation
- Document fixed anterior angulation in code comments and README

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2600bc0c832eb52757ab304e691d