### PR TITLE
Add fluoroscopy mode with toggle button

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This prototype demonstrates a basic browser-based simulator for guiding a stiff 
 
 Open `index.html` in a modern browser. Use `W`/`S` or the up/down arrow keys to advance or retract the guidewire through the introducer sheath positioned in the left branch. The sheath exits this branch with a fixed 30° anterior (+Z) angulation, and the push distance now allows the wire to be fully inserted if desired.
 
+Click the **Fluoroscopy** button to hide the vessel and display only the guidewire. Click again to return to the wireframe view.
+
 ## Vessel Geometry
 
 The vessel is generated deterministically. Branch length and angle offset use fixed defaults (140 units and 0 radians) and only change when explicitly provided to `generateVessel`. The introducer sheath extends from the left branch with a 30° anterior (+Z) tilt.

--- a/index.html
+++ b/index.html
@@ -65,9 +65,7 @@
     <label>C-arm Z
         <input id="carmZ" type="range" min="-200" max="200" step="1" value="200">
     </label>
-    <label>Wireframe
-        <input id="wireframe" type="checkbox">
-    </label>
+    <button id="modeToggle">Fluoroscopy</button>
 </div>
 <script type="importmap">
 {

--- a/simulator.js
+++ b/simulator.js
@@ -71,7 +71,7 @@ const staticFricSlider = document.getElementById('staticFriction');
 const kineticFricSlider = document.getElementById('kineticFriction');
 const dampingSlider = document.getElementById('normalDamping');
 const velDampingSlider = document.getElementById('velocityDamping');
-const wireframeToggle = document.getElementById('wireframe');
+const modeToggle = document.getElementById('modeToggle');
 const insertedLength = document.getElementById('insertedLength');
 
 const sliders = [
@@ -115,9 +115,11 @@ velDampingSlider.addEventListener('input', e => {
     setVelocityDamping(velocityDamping);
 });
 
-
-wireframeToggle.addEventListener('change', e => {
-    vesselMaterial.wireframe = e.target.checked;
+let fluoroscopy = false;
+modeToggle.addEventListener('click', () => {
+    fluoroscopy = !fluoroscopy;
+    vesselGroup.visible = !fluoroscopy;
+    modeToggle.textContent = fluoroscopy ? 'Wireframe' : 'Fluoroscopy';
 });
 
 const wireMaterial = new THREE.LineBasicMaterial({color: 0xffffff});


### PR DESCRIPTION
## Summary
- Add Fluoroscopy button to switch between vessel wireframe view and fluoroscopy mode with only the guidewire visible.
- Implement JavaScript handler that toggles vessel visibility and updates button text.
- Document the new Fluoroscopy toggle in the README.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae291ea55c832e8cae9c44624380a0