### PR TITLE
Fix camera roll orientation in C-arm controls

### DIFF
--- a/carm.js
+++ b/carm.js
@@ -39,8 +39,9 @@ export function setupCArmControls(camera, vessel, cameraRadius) {
             new THREE.Spherical(cameraRadius, Math.PI / 2 - carmPitch, carmYaw)
         );
         camera.position.copy(pivot).add(offset);
+        camera.up.set(0, 1, 0);
         camera.lookAt(pivot);
-        camera.rotation.z = carmRoll;
+        camera.rotateZ(carmRoll);
     }
 
     updateCamera();


### PR DESCRIPTION
## Summary
- Ensure camera uses world-up before orienting toward target
- Apply roll after `lookAt` to preserve orientation

## Testing
- `node - <<'NODE' import * as THREE from 'three'; ... NODE`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2c6e9ff4832ebe5123338fa6f74f