### PR TITLE
Skip fluoroscopy rendering when disabled

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -238,23 +238,29 @@ function animate(time) {
     }
 
     updateWireMesh();
-    renderer.setRenderTarget(offscreenTarget);
-    renderer.clear();
-    renderer.render(scene, camera);
 
-    blendMaterial.uniforms.currentFrame.value = offscreenTarget.texture;
-    blendMaterial.uniforms.previousFrame.value = previousTarget.texture;
+    if (fluoroscopy) {
+        renderer.setRenderTarget(offscreenTarget);
+        renderer.clear();
+        renderer.render(scene, camera);
 
-    renderer.setRenderTarget(currentTarget);
-    renderer.render(blendScene, postCamera);
-    renderer.setRenderTarget(null);
+        blendMaterial.uniforms.currentFrame.value = offscreenTarget.texture;
+        blendMaterial.uniforms.previousFrame.value = previousTarget.texture;
 
-    displayMaterial.uniforms.uTexture.value = currentTarget.texture;
-    renderer.render(displayScene, postCamera);
+        renderer.setRenderTarget(currentTarget);
+        renderer.render(blendScene, postCamera);
+        renderer.setRenderTarget(null);
 
-    const temp = previousTarget;
-    previousTarget = currentTarget;
-    currentTarget = temp;
+        displayMaterial.uniforms.uTexture.value = currentTarget.texture;
+        renderer.render(displayScene, postCamera);
+
+        const temp = previousTarget;
+        previousTarget = currentTarget;
+        currentTarget = temp;
+    } else {
+        renderer.setRenderTarget(null);
+        renderer.render(scene, camera);
+    }
 
     requestAnimationFrame(animate);
 }


### PR DESCRIPTION
## Summary
- Render scene directly when fluoroscopy mode is off
- Keep existing offscreen blending pipeline only for fluoroscopy mode

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68ae32b78da0832e8ce3ebdee2d6edbe