### PR TITLE
Add configurable fluoroscopy noise effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,9 @@
     <label>Persistence
         <input id="persistence" type="range" min="0.85" max="0.99" step="0.01" value="0.95">
     </label>
+    <label>Noise level
+        <input id="noiseLevel" type="range" min="0" max="0.2" step="0.01" value="0.05">
+    </label>
     <label>C-arm yaw
         <input id="carmYaw" type="range" min="-180" max="180" step="1" value="0">
     </label>


### PR DESCRIPTION
## Summary
- Add time-varying pseudo-random noise to the fluoroscopy shader and perturb intensity
- Pass frame time to shader and expose noise level uniform with UI slider

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae32bbeb9c832e8029de851eb41cf0