### PR TITLE
Disable shader in wireframe and show slider values

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,42 +34,55 @@
     <div id="insertedLength">0 cm</div>
     <label>Bending stiffness
         <input id="stiffness" type="range" min="0" max="2" step="0.1" value="0.8">
+        <span></span>
     </label>
     <label>Static friction
         <input id="staticFriction" type="range" min="0" max="1" step="0.01" value="0.2">
+        <span></span>
     </label>
     <label>Kinetic friction
         <input id="kineticFriction" type="range" min="0" max="1" step="0.01" value="0.1">
+        <span></span>
     </label>
     <label>Normal damping
         <input id="normalDamping" type="range" min="0" max="1" step="0.01" value="0.5">
+        <span></span>
     </label>
     <label>Velocity damping
         <input id="velocityDamping" type="range" min="0" max="1" step="0.01" value="0.98">
+        <span></span>
     </label>
     <label>Persistence
         <input id="persistence" type="range" min="0.25" max="0.99" step="0.01" value="0.35">
+        <span></span>
     </label>
     <label>Noise level
         <input id="noiseLevel" type="range" min="0" max="0.2" step="0.01" value="0.05">
+        <span></span>
     </label>
     <label>C-arm yaw
         <input id="carmYaw" type="range" min="-180" max="180" step="1" value="0">
+        <span></span>
     </label>
     <label>C-arm pitch
         <input id="carmPitch" type="range" min="-90" max="90" step="1" value="0">
+        <span></span>
     </label>
     <label>C-arm roll
         <input id="carmRoll" type="range" min="-180" max="180" step="1" value="0">
+        <span></span>
     </label>
     <label>C-arm X
         <input id="carmX" type="range" min="-200" max="200" step="1" value="0">
+        <span></span>
     </label>
     <label>C-arm Y
         <input id="carmY" type="range" min="-200" max="200" step="1" value="0">
+        <span></span>
     </label>
     <label>C-arm Z
         <input id="carmZ" type="range" min="-200" max="400" step="1" value="400">
+        <span></span>
     </label>
     <button id="modeToggle">Fluoroscopy</button>
 </div>

--- a/simulator.js
+++ b/simulator.js
@@ -169,6 +169,15 @@ const sliders = [
     noiseSlider
 ];
 sliders.forEach(s => s.addEventListener('change', () => s.blur()));
+
+// Display current values next to each slider
+document.querySelectorAll('#controls input[type="range"]').forEach(slider => {
+    const valueLabel = slider.nextElementSibling;
+    if (!valueLabel) return;
+    const update = () => { valueLabel.textContent = slider.value; };
+    update();
+    slider.addEventListener('input', update);
+});
 setupCArmControls(camera, vessel, cameraRadius);
 
 displayMaterial.uniforms.noiseLevel.value = parseFloat(noiseSlider.value);
@@ -257,24 +266,29 @@ function animate(time) {
     }
 
     updateWireMesh();
-    renderer.setRenderTarget(offscreenTarget);
-    renderer.clear();
-    renderer.render(scene, camera);
+    if (fluoroscopy) {
+        renderer.setRenderTarget(offscreenTarget);
+        renderer.clear();
+        renderer.render(scene, camera);
 
-    blendMaterial.uniforms.currentFrame.value = offscreenTarget.texture;
-    blendMaterial.uniforms.previousFrame.value = previousTarget.texture;
+        blendMaterial.uniforms.currentFrame.value = offscreenTarget.texture;
+        blendMaterial.uniforms.previousFrame.value = previousTarget.texture;
 
-    renderer.setRenderTarget(currentTarget);
-    renderer.render(blendScene, postCamera);
-    renderer.setRenderTarget(null);
+        renderer.setRenderTarget(currentTarget);
+        renderer.render(blendScene, postCamera);
+        renderer.setRenderTarget(null);
 
-    displayMaterial.uniforms.uTexture.value = currentTarget.texture;
-    displayMaterial.uniforms.time.value = time * 0.001;
-    renderer.render(displayScene, postCamera);
+        displayMaterial.uniforms.uTexture.value = currentTarget.texture;
+        displayMaterial.uniforms.time.value = time * 0.001;
+        renderer.render(displayScene, postCamera);
 
-    const temp = previousTarget;
-    previousTarget = currentTarget;
-    currentTarget = temp;
+        const temp = previousTarget;
+        previousTarget = currentTarget;
+        currentTarget = temp;
+    } else {
+        renderer.setRenderTarget(null);
+        renderer.render(scene, camera);
+    }
 
     requestAnimationFrame(animate);
 }


### PR DESCRIPTION
## Summary
- Skip post-processing shader when not in fluoroscopy (wireframe) mode to boost performance
- Display current numeric values next to all sliders in the UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae36015694832ea3e5d9d93b802156