### PR TITLE
Add contrast agent rendering to simulator

### DIFF
--- a/contrastAgent.js
+++ b/contrastAgent.js
@@ -66,6 +66,6 @@ export function getContrastGeometry(agent) {
         }
     }
     const geometry = new THREE.BufferGeometry().setFromPoints(points);
-    const material = new THREE.LineBasicMaterial({ color: 0xff0000 });
+    const material = new THREE.LineBasicMaterial({ color: 0xffffff });
     return new THREE.Line(geometry, material);
 }


### PR DESCRIPTION
## Summary
- import and instantiate the contrast agent module
- update render loop to drive contrast geometry and hide vessel mesh when active
- brighten contrast material for fluoroscopy blending

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae38ca4328832ead2c1710f397d25c