### PR TITLE
Add manual contrast injection control

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,7 @@
         <input id="carmZ" type="range" min="-200" max="400" step="1" value="400">
         <span></span>
     </label>
+    <button id="injectContrast">Inject</button>
     <button id="modeToggle">Fluoroscopy</button>
 </div>
 <script type="importmap">

--- a/simulator.js
+++ b/simulator.js
@@ -113,7 +113,6 @@ vesselGroup.add(vesselMesh);
 scene.add(vesselGroup);
 
 const contrast = new ContrastAgent(vessel.segments, 0);
-contrast.start();
 let contrastMesh = getContrastGeometry(contrast);
 if (contrastMesh) {
     contrastMesh.visible = false;
@@ -150,6 +149,12 @@ document.addEventListener('keydown', e => {
         advance = -1;
         e.preventDefault();
     }
+    if (e.code === 'KeyC' && fluoroscopy) {
+        if (!contrast.isActive()) {
+            contrast.start();
+        }
+        e.preventDefault();
+    }
 }, true);
 document.addEventListener('keyup', e => {
     if (['KeyW', 'KeyS', 'ArrowUp', 'ArrowDown'].includes(e.code)) {
@@ -164,6 +169,7 @@ const kineticFricSlider = document.getElementById('kineticFriction');
 const dampingSlider = document.getElementById('normalDamping');
 const velDampingSlider = document.getElementById('velocityDamping');
 const modeToggle = document.getElementById('modeToggle');
+const injectButton = document.getElementById('injectContrast');
 const insertedLength = document.getElementById('insertedLength');
 const persistenceSlider = document.getElementById('persistence');
 const noiseSlider = document.getElementById('noiseLevel');
@@ -238,6 +244,13 @@ modeToggle.addEventListener('click', () => {
     modeToggle.textContent = fluoroscopy ? 'Wireframe' : 'Fluoroscopy';
 });
 
+injectButton.addEventListener('click', () => {
+    if (!contrast.isActive()) {
+        contrast.start();
+        injectButton.disabled = true;
+    }
+});
+
 const wireMaterial = new THREE.LineBasicMaterial({color: 0xffffff});
 const wireGeometry = new THREE.BufferGeometry();
 const wirePositions = new Float32Array(nodeCount * 3);
@@ -289,6 +302,7 @@ function animate(time) {
     } else {
         vesselGroup.visible = !fluoroscopy;
     }
+    injectButton.disabled = contrast.isActive();
     if (fluoroscopy) {
         renderer.setRenderTarget(offscreenTarget);
         renderer.clear();


### PR DESCRIPTION
## Summary
- Add "Inject" button to UI for manual contrast injection
- Start contrast injection on button click or `C` key when in fluoroscopy mode
- Disable inject button while contrast injection is active

## Testing
- `node --check simulator.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae3a08674c832e89c5dda19bbd3050