### PR TITLE
Add contrast decay and reset injection controls

### DIFF
--- a/contrastAgent.js
+++ b/contrastAgent.js
@@ -1,10 +1,11 @@
 import * as THREE from 'three';
 
 export class ContrastAgent {
-    constructor(segments, startIndex, speed = 50) {
+    constructor(segments, startIndex, speed = 50, decayDelay = 2) {
         this.segments = segments;
         this.startIndex = startIndex;
         this.speed = speed;
+        this.decayDelay = decayDelay;
         this.segmentLengths = [];
         this.cumulativeLengths = [];
         let cumulative = 0;
@@ -22,19 +23,35 @@ export class ContrastAgent {
         this.totalLength = cumulative;
         this.filledLength = 0;
         this.active = false;
+        this.injecting = false;
+        this.decayTimer = 0;
     }
 
     start() {
         this.filledLength = 0;
         this.active = true;
+        this.injecting = true;
+        this.decayTimer = 0;
     }
 
     update(dt) {
         if (!this.active) return;
-        this.filledLength += this.speed * dt;
-        if (this.filledLength >= this.totalLength) {
-            this.filledLength = this.totalLength;
-            this.active = false;
+
+        if (this.injecting) {
+            this.filledLength += this.speed * dt;
+            if (this.filledLength >= this.totalLength) {
+                this.filledLength = this.totalLength;
+                this.injecting = false;
+                this.decayTimer = this.decayDelay;
+            }
+        } else if (this.decayTimer > 0) {
+            this.decayTimer -= dt;
+        } else {
+            this.filledLength -= this.speed * dt;
+            if (this.filledLength <= 0) {
+                this.filledLength = 0;
+                this.active = false;
+            }
         }
     }
 

--- a/simulator.js
+++ b/simulator.js
@@ -289,20 +289,24 @@ function animate(time) {
 
     updateWireMesh();
     contrast.update(dt);
-    if (contrastMesh) {
-        scene.remove(contrastMesh);
-        contrastMesh = null;
-    }
     if (contrast.isActive()) {
+        if (contrastMesh) {
+            scene.remove(contrastMesh);
+        }
         contrastMesh = getContrastGeometry(contrast);
         if (contrastMesh) {
             scene.add(contrastMesh);
         }
         vesselGroup.visible = false;
+        injectButton.disabled = true;
     } else {
+        if (contrastMesh) {
+            scene.remove(contrastMesh);
+            contrastMesh = null;
+        }
         vesselGroup.visible = !fluoroscopy;
+        injectButton.disabled = false;
     }
-    injectButton.disabled = contrast.isActive();
     if (fluoroscopy) {
         renderer.setRenderTarget(offscreenTarget);
         renderer.clear();


### PR DESCRIPTION
## Summary
- add configurable decay timing to contrast agent to gradually clear contrast
- remove contrast geometry and re-enable injection control when agent finishes

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68ae3b17f8d4832ea88b5a09a6ae92a9