### PR TITLE
Set BP monitor line to red and reset context

### DIFF
--- a/patientMonitor.js
+++ b/patientMonitor.js
@@ -121,8 +121,10 @@ export class PatientMonitor {
         for (let i = 1; i < w; i++) {
             ctx.lineTo(i, mapY(this.bpData[i]));
         }
-        ctx.strokeStyle = 'yellow';
+        ctx.save();
+        ctx.strokeStyle = '#ff0000';
         ctx.stroke();
+        ctx.restore();
     }
 }
 


### PR DESCRIPTION
## Summary
- Render blood pressure waveform in red and restore canvas state to avoid affecting other plots

## Testing
- `node --check patientMonitor.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae3d622f68832ebaf0f4a17a802af8