### PR TITLE
feat: deterministic vitals and value boxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,23 @@
             margin-bottom: 5px;
         }
 
-        #vitalValues span {
-            margin: 0 5px;
+        .vitalBox {
+            width: 300px;
+            border: 1px solid;
+            padding: 2px;
+            margin: -3px auto 5px auto;
+            text-align: center;
+            font-family: sans-serif;
+        }
+
+        #hrBox {
+            border-color: lime;
+            color: lime;
+        }
+
+        #bpBox {
+            border-color: red;
+            color: red;
         }
     </style>
 </head>
@@ -109,8 +124,9 @@
 
 <div id="monitor">
     <canvas id="ecgCanvas" width="300" height="100"></canvas>
+    <div id="hrBox" class="vitalBox">HR: <span id="hrValue">0</span></div>
     <canvas id="bpCanvas" width="300" height="100"></canvas>
-    <div id="vitalValues"><span id="hrValue">HR: 0</span> <span id="bpValue">BP: 0/0</span></div>
+    <div id="bpBox" class="vitalBox">BP: <span id="bpValue">0/0</span></div>
 </div>
 
 <script type="importmap">


### PR DESCRIPTION
## Summary
- replace noisy vitals with templates: deterministic P‑QRS‑T ECG and dicrotic notch BP waveforms
- allow heart rate control and stream samples from templates
- show HR and BP values in colored boxes under respective graphs

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -e "import('./patientMonitor.js').then(()=>console.log('ok')).catch(err=>console.error(err));"`

------
https://chatgpt.com/codex/tasks/task_e_68ae407167dc832eb6c00e2379f2dea1