### PR TITLE
Simulate contrast concentration propagation

### DIFF
--- a/contrastAgent.js
+++ b/contrastAgent.js
@@ -1,88 +1,90 @@
 import * as THREE from 'three';
 
+// Simulates advection of a contrast agent through a vessel graph.
 export class ContrastAgent {
-    constructor(segments, startIndex, speed = 50, decayDelay = 2) {
-        this.segments = segments;
-        this.startIndex = startIndex;
-        this.speed = speed;
-        this.decayDelay = decayDelay;
-        this.segmentLengths = [];
-        this.cumulativeLengths = [];
-        let cumulative = 0;
-        for (let i = startIndex; i < segments.length; i++) {
-            const s = segments[i];
-            const len = Math.sqrt(
-                (s.end.x - s.start.x) * (s.end.x - s.start.x) +
-                (s.end.y - s.start.y) * (s.end.y - s.start.y) +
-                (s.end.z - s.start.z) * (s.end.z - s.start.z)
-            );
-            this.segmentLengths.push(len);
-            cumulative += len;
-            this.cumulativeLengths.push(cumulative);
-        }
-        this.totalLength = cumulative;
-        this.filledLength = 0;
-        this.active = false;
-        this.injecting = false;
-        this.decayTimer = 0;
+    constructor(vessel, washout = 0.5) {
+        this.vessel = vessel;
+        this.segments = vessel.segments;
+        this.graph = vessel.segmentGraph;
+        this.washout = washout;
+
+        this.lengths = this.segments.map(s => {
+            const dx = s.end.x - s.start.x;
+            const dy = s.end.y - s.start.y;
+            const dz = s.end.z - s.start.z;
+            return Math.sqrt(dx * dx + dy * dy + dz * dz) || 1;
+        });
+        this.concentration = new Array(this.segments.length).fill(0);
+
+        const eps = 1e-6;
+        const equal = (a, b) =>
+            Math.abs(a.x - b.x) < eps &&
+            Math.abs(a.y - b.y) < eps &&
+            Math.abs(a.z - b.z) < eps;
+        this.sheathIndex = this.segments.findIndex(
+            s => equal(s.end, vessel.left.end)
+        );
+        if (this.sheathIndex === -1) this.sheathIndex = 0;
     }
 
-    start() {
-        this.filledLength = 0;
-        this.active = true;
-        this.injecting = true;
-        this.decayTimer = 0;
+    // Adds concentration into the segment connected to the sheath.
+    inject(rate) {
+        if (this.sheathIndex >= 0) {
+            this.concentration[this.sheathIndex] += rate;
+        }
     }
 
     update(dt) {
-        if (!this.active) return;
+        const next = new Array(this.segments.length).fill(0);
+        for (let i = 0; i < this.segments.length; i++) {
+            const seg = this.segments[i];
+            const speed = seg.flowSpeed || 0;
+            const frac = Math.min(1, (speed * dt) / this.lengths[i]);
+            const moved = this.concentration[i] * frac;
+            const remain = this.concentration[i] - moved;
 
-        if (this.injecting) {
-            this.filledLength += this.speed * dt;
-            if (this.filledLength >= this.totalLength) {
-                this.filledLength = this.totalLength;
-                this.injecting = false;
-                this.decayTimer = this.decayDelay;
+            const children = this.graph[i] || [];
+            if (children.length) {
+                let total = 0;
+                for (const c of children) total += this.segments[c].flowSpeed || 0;
+                for (const c of children) {
+                    const w = total > 0 ? (this.segments[c].flowSpeed || 0) / total : 1 / children.length;
+                    next[c] += moved * w;
+                }
             }
-        } else if (this.decayTimer > 0) {
-            this.decayTimer -= dt;
-        } else {
-            this.filledLength -= this.speed * dt;
-            if (this.filledLength <= 0) {
-                this.filledLength = 0;
-                this.active = false;
-            }
+            next[i] += remain;
         }
+        const decay = Math.exp(-this.washout * dt);
+        for (let i = 0; i < next.length; i++) {
+            next[i] *= decay;
+        }
+        this.concentration = next;
     }
 
     isActive() {
-        return this.active;
+        return this.concentration.some(c => c > 1e-3);
     }
 }
 
+// Generate TubeGeometry representing current contrast distribution.
 export function getContrastGeometry(agent) {
-    if (!agent || agent.filledLength <= 0) return null;
-    const points = [];
-    let remaining = agent.filledLength;
-    const baseIndex = agent.startIndex;
-    const firstSeg = agent.segments[baseIndex];
-    points.push(new THREE.Vector3(firstSeg.start.x, firstSeg.start.y, firstSeg.start.z));
-    for (let i = 0; i < agent.segmentLengths.length && remaining > 0; i++) {
-        const seg = agent.segments[baseIndex + i];
-        const length = agent.segmentLengths[i];
-        if (remaining >= length) {
-            points.push(new THREE.Vector3(seg.end.x, seg.end.y, seg.end.z));
-            remaining -= length;
-        } else {
-            const t = remaining / length;
-            const endX = seg.start.x + (seg.end.x - seg.start.x) * t;
-            const endY = seg.start.y + (seg.end.y - seg.start.y) * t;
-            const endZ = seg.start.z + (seg.end.z - seg.start.z) * t;
-            points.push(new THREE.Vector3(endX, endY, endZ));
-            remaining = 0;
-        }
+    if (!agent || !agent.isActive()) return null;
+    const group = new THREE.Group();
+    for (let i = 0; i < agent.segments.length; i++) {
+        const c = agent.concentration[i];
+        if (c <= 1e-3) continue;
+        const seg = agent.segments[i];
+        const start = new THREE.Vector3(seg.start.x, seg.start.y, seg.start.z);
+        const end = new THREE.Vector3(seg.end.x, seg.end.y, seg.end.z);
+        const path = new THREE.LineCurve3(start, end);
+        const geom = new THREE.TubeGeometry(path, 4, seg.radius * 0.9, 8, false);
+        const opacity = Math.min(c, 1);
+        const material = new THREE.MeshBasicMaterial({
+            color: new THREE.Color(opacity, opacity, opacity),
+            transparent: true,
+            opacity
+        });
+        group.add(new THREE.Mesh(geom, material));
     }
-    const geometry = new THREE.BufferGeometry().setFromPoints(points);
-    const material = new THREE.LineBasicMaterial({ color: 0xffffff });
-    return new THREE.Line(geometry, material);
+    return group.children.length ? group : null;
 }


### PR DESCRIPTION
## Summary
- Track per-segment contrast concentrations and inject via sheath-connected segment
- Advect and wash out contrast according to vessel flow, distributing at branches
- Render contrast as tube geometries with opacity tied to concentration; update simulator to drive injection

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68ae41adcb00832eb3b5a38a46d8eb49