### PR TITLE
Move vital signs beside waveforms

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,23 +33,30 @@
             right: 10px;
             color: white;
             font-family: sans-serif;
-            text-align: center;
+            display: flex;
+            flex-direction: column;
         }
 
         #monitor canvas {
             background: black;
             border: 1px solid white;
             display: block;
+            margin-right: 8px;
+        }
+
+        .vitalRow {
+            display: flex;
+            align-items: center;
             margin-bottom: 5px;
         }
 
         .vitalBox {
-            width: 300px;
             border: 1px solid;
-            padding: 2px;
-            margin: -3px auto 5px auto;
+            padding: 2px 6px;
+            margin-left: 0;
             text-align: center;
             font-family: sans-serif;
+            font-size: 28px;
         }
 
         #hrBox {
@@ -123,10 +130,14 @@
 </div>
 
 <div id="monitor">
-    <canvas id="ecgCanvas" width="300" height="100"></canvas>
-    <div id="hrBox" class="vitalBox">HR: <span id="hrValue">0</span></div>
-    <canvas id="bpCanvas" width="300" height="100"></canvas>
-    <div id="bpBox" class="vitalBox">BP: <span id="bpValue">0/0</span></div>
+    <div class="vitalRow">
+        <canvas id="ecgCanvas" width="300" height="100"></canvas>
+        <div id="hrBox" class="vitalBox">HR: <span id="hrValue">0</span></div>
+    </div>
+    <div class="vitalRow">
+        <canvas id="bpCanvas" width="300" height="100"></canvas>
+        <div id="bpBox" class="vitalBox">BP: <span id="bpValue">0/0</span></div>
+    </div>
 </div>
 
 <script type="importmap">


### PR DESCRIPTION
## Summary
- Lay out ECG and BP displays with flex rows so HR and BP values sit beside their waveforms
- Increase vital sign font size for better readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae423c27ac832eaedd5e6f8046720d