### PR TITLE
feat: add contrast overlay with persistence

### DIFF
--- a/contrastAgent.js
+++ b/contrastAgent.js
@@ -66,10 +66,12 @@ export class ContrastAgent {
     }
 }
 
-// Generate TubeGeometry representing current contrast distribution.
+// Generate TubeGeometry for segments with contrast.  The caller is
+// responsible for assigning materials based on the returned
+// concentration value.
 export function getContrastGeometry(agent) {
-    if (!agent || !agent.isActive()) return null;
-    const group = new THREE.Group();
+    if (!agent || !agent.isActive()) return [];
+    const geoms = [];
     for (let i = 0; i < agent.segments.length; i++) {
         const c = agent.concentration[i];
         if (c <= 1e-3) continue;
@@ -78,13 +80,7 @@ export function getContrastGeometry(agent) {
         const end = new THREE.Vector3(seg.end.x, seg.end.y, seg.end.z);
         const path = new THREE.LineCurve3(start, end);
         const geom = new THREE.TubeGeometry(path, 4, seg.radius * 0.9, 8, false);
-        const opacity = Math.min(c, 1);
-        const material = new THREE.MeshBasicMaterial({
-            color: new THREE.Color(opacity, opacity, opacity),
-            transparent: true,
-            opacity
-        });
-        group.add(new THREE.Mesh(geom, material));
+        geoms.push({ geometry: geom, concentration: c });
     }
-    return group.children.length ? group : null;
+    return geoms;
 }


### PR DESCRIPTION
## Summary
- generate contrast geometry each frame and apply transparent materials with concentration-based opacity
- add `contrastTexture` uniform to display shader to brighten pixels in fluoroscopy
- ensure contrast overlay fades in fluoroscopy mode with blend persistence

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae43327b5c832eb58323ec2e7810b8