### PR TITLE
Add contrast injection controls and dose tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
 <canvas id="sim"></canvas>
 <div id="controls">
     <div id="insertedLength">0 cm</div>
+    <div id="currentDose">0 ml</div>
     <label>Bending stiffness
         <input id="stiffness" type="range" min="0" max="2" step="0.1" value="0.8">
         <span></span>
@@ -103,6 +104,14 @@
     <label>Noise level
         <input id="noiseLevel" type="range" min="0" max="0.6" step="0.01" value="0.3">
     </label>
+    <label>Injection rate (ml/s)
+        <input id="injRate" type="range" min="0" max="10" step="0.1" value="1">
+        <span></span>
+    </label>
+    <label>Injection duration (ms)
+        <input id="injDuration" type="range" min="0" max="5000" step="100" value="1000">
+        <span></span>
+    </label>
     <label>C-arm yaw
         <input id="carmYaw" type="range" min="-180" max="180" step="1" value="0">
         <span></span>
@@ -128,6 +137,7 @@
         <span></span>
     </label>
     <button id="injectContrast">Inject</button>
+    <button id="stopInjection" disabled>Stop Injection</button>
     <button id="modeToggle">Fluoroscopy</button>
 </div>
 


### PR DESCRIPTION
## Summary
- Add UI sliders for injection rate and duration along with a stop button and dose display
- Manage contrast injection for specified duration with optional early stop and live dose tracking

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae44df4058832ead90422bfd93f2fe