### PR TITLE
Add C-arm preview scene and initialization

### DIFF
--- a/carmPreview.js
+++ b/carmPreview.js
@@ -1,0 +1,29 @@
+import * as THREE from 'three';
+
+let previewScene;
+let previewCamera;
+let previewRenderer;
+
+export function initCArmPreview() {
+    const container = document.getElementById('carm-preview');
+    if (!container) return;
+
+    previewScene = new THREE.Scene();
+    const width = container.clientWidth;
+    const height = container.clientHeight;
+
+    previewCamera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
+    previewCamera.position.set(0, 0, 5);
+    previewScene.add(previewCamera);
+
+    previewRenderer = new THREE.WebGLRenderer({ antialias: true });
+    previewRenderer.setSize(width, height);
+    container.appendChild(previewRenderer.domElement);
+}
+
+export function renderCArmPreview() {
+    if (!previewRenderer || !previewScene || !previewCamera) return;
+    previewRenderer.render(previewScene, previewCamera);
+}
+
+export { previewScene as cArmPreviewScene, previewCamera as cArmPreviewCamera };

--- a/simulator.js
+++ b/simulator.js
@@ -6,6 +6,7 @@ import { ContrastAgent, getContrastGeometry } from './contrastAgent.js';
 import { PatientMonitor } from './patientMonitor.js';
 import { createCArmModel } from './carmModel.js';
 import { createOperatingTable } from './operatingTable.js';
+import { initCArmPreview, renderCArmPreview } from './carmPreview.js';
 
 const canvas = document.getElementById('sim');
 const renderer = new THREE.WebGLRenderer({canvas, antialias: true});
@@ -20,6 +21,8 @@ const monitor = new PatientMonitor(
     document.getElementById('hrValue'),
     document.getElementById('bpValue')
 );
+
+initCArmPreview();
 
 const offscreenTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
 const accumulateTarget1 = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
@@ -394,6 +397,8 @@ function animate(time) {
         renderer.setRenderTarget(null);
         renderer.render(scene, camera);
     }
+
+    renderCArmPreview();
 
     requestAnimationFrame(animate);
 }


### PR DESCRIPTION
## Summary
- create `carmPreview.js` with scene, camera and renderer helpers
- initialize and render C-arm preview from `simulator.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4723d9e0832e8a515f76e5f04bc7