### PR TITLE
Display C-arm rig in preview

### DIFF
--- a/carmPreview.js
+++ b/carmPreview.js
@@ -1,24 +1,46 @@
 import * as THREE from 'three';
+import { createCArmModel } from './carmModel.js';
+import { createOperatingTable } from './operatingTable.js';
 
 let previewScene;
 let previewCamera;
 let previewRenderer;
+let cArmGroup;
 
 export function initCArmPreview() {
     const container = document.getElementById('carm-preview');
     if (!container) return;
 
     previewScene = new THREE.Scene();
+
+    // Simple lighting so models are visible in the preview.
+    const ambient = new THREE.AmbientLight(0xffffff, 0.8);
+    previewScene.add(ambient);
+    const dirLight = new THREE.DirectionalLight(0xffffff, 0.5);
+    dirLight.position.set(1, 1, 1);
+    previewScene.add(dirLight);
+
     const width = container.clientWidth;
     const height = container.clientHeight;
 
     previewCamera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
-    previewCamera.position.set(0, 0, 5);
+    previewCamera.position.set(200, 150, 300);
+    previewCamera.lookAt(0, 0, 0);
     previewScene.add(previewCamera);
 
     previewRenderer = new THREE.WebGLRenderer({ antialias: true });
     previewRenderer.setSize(width, height);
     container.appendChild(previewRenderer.domElement);
+
+    const table = createOperatingTable();
+    table.position.y = -75; // place table so the top aligns with the origin
+    previewScene.add(table);
+
+    cArmGroup = new THREE.Group();
+    const cArm = createCArmModel();
+    cArm.position.y = -70; // align gantry center with the group's origin
+    cArmGroup.add(cArm);
+    previewScene.add(cArmGroup);
 }
 
 export function renderCArmPreview() {
@@ -26,4 +48,4 @@ export function renderCArmPreview() {
     previewRenderer.render(previewScene, previewCamera);
 }
 
-export { previewScene as cArmPreviewScene, previewCamera as cArmPreviewCamera };
+export { previewScene as cArmPreviewScene, previewCamera as cArmPreviewCamera, cArmGroup as cArmPreviewGroup };


### PR DESCRIPTION
## Summary
- Import and integrate C-arm and operating table models into preview scene
- Position rig components and add basic lighting for visibility
- Export C-arm preview group for external pose updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae47a5c2b0832e9e4e1d26da1ca772