### PR TITLE
Organize simulator controls into collapsible sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,16 @@
             margin-bottom: 4px;
         }
 
+        .section-header {
+            cursor: pointer;
+            font-weight: bold;
+            margin-top: 8px;
+        }
+
+        .section-content.hidden {
+            display: none;
+        }
+
         #monitor {
             position: absolute;
             top: 10px;
@@ -93,65 +103,96 @@
 <div id="controls">
     <div id="insertedLength">0 cm</div>
     <div id="currentDose">0 ml</div>
-    <label>Bending stiffness
-        <input id="stiffness" type="range" min="0" max="2" step="0.1" value="0.8">
-        <span></span>
-    </label>
-    <label>Static friction
-        <input id="staticFriction" type="range" min="0" max="1" step="0.01" value="0.2">
-        <span></span>
-    </label>
-    <label>Kinetic friction
-        <input id="kineticFriction" type="range" min="0" max="1" step="0.01" value="0.1">
-        <span></span>
-    </label>
-    <label>Normal damping
-        <input id="normalDamping" type="range" min="0" max="1" step="0.01" value="0.5">
-        <span></span>
-    </label>
-    <label>Velocity damping
-        <input id="velocityDamping" type="range" min="0" max="1" step="0.01" value="0.98">
-        <span></span>
-    </label>
-    <label>Persistence
-        <input id="persistence" type="range" min="0.25" max="0.99" step="0.01" value="0.35">
-        <span></span>
-    </label>
-    <label>Noise level
-        <input id="noiseLevel" type="range" min="0" max="0.6" step="0.01" value="0.3">
-    </label>
-    <label>Injection rate (ml/s)
-        <input id="injRate" type="range" min="0" max="10" step="0.1" value="1">
-        <span></span>
-    </label>
-    <label>Injection duration (ms)
-        <input id="injDuration" type="range" min="0" max="5000" step="100" value="1000">
-        <span></span>
-    </label>
-    <label>C-arm yaw
-        <input id="carmYaw" type="range" min="-180" max="180" step="1" value="0">
-        <span></span>
-    </label>
-    <label>C-arm pitch
-        <input id="carmPitch" type="range" min="-90" max="90" step="1" value="0">
-        <span></span>
-    </label>
-    <label>C-arm roll
-        <input id="carmRoll" type="range" min="-180" max="180" step="1" value="0">
-        <span></span>
-    </label>
-    <label>C-arm X
-        <input id="carmX" type="range" min="-200" max="200" step="1" value="0">
-        <span></span>
-    </label>
-    <label>C-arm Y
-        <input id="carmY" type="range" min="-200" max="200" step="1" value="0">
-        <span></span>
-    </label>
-    <label>C-arm Z
-        <input id="carmZ" type="range" min="-200" max="400" step="1" value="400">
-        <span></span>
-    </label>
+
+    <div class="control-section">
+        <div class="section-header">Guidewire</div>
+        <div class="section-content">
+            <label>Bending stiffness
+                <input id="stiffness" type="range" min="0" max="2" step="0.1" value="0.8">
+                <span></span>
+            </label>
+            <label>Normal damping
+                <input id="normalDamping" type="range" min="0" max="1" step="0.01" value="0.5">
+                <span></span>
+            </label>
+            <label>Velocity damping
+                <input id="velocityDamping" type="range" min="0" max="1" step="0.01" value="0.98">
+                <span></span>
+            </label>
+        </div>
+    </div>
+
+    <div class="control-section">
+        <div class="section-header">Friction</div>
+        <div class="section-content">
+            <label>Static friction
+                <input id="staticFriction" type="range" min="0" max="1" step="0.01" value="0.2">
+                <span></span>
+            </label>
+            <label>Kinetic friction
+                <input id="kineticFriction" type="range" min="0" max="1" step="0.01" value="0.1">
+                <span></span>
+            </label>
+        </div>
+    </div>
+
+    <div class="control-section">
+        <div class="section-header">Imaging</div>
+        <div class="section-content">
+            <label>Persistence
+                <input id="persistence" type="range" min="0.25" max="0.99" step="0.01" value="0.35">
+                <span></span>
+            </label>
+            <label>Noise level
+                <input id="noiseLevel" type="range" min="0" max="0.6" step="0.01" value="0.3">
+            </label>
+        </div>
+    </div>
+
+    <div class="control-section">
+        <div class="section-header">Injection</div>
+        <div class="section-content">
+            <label>Injection rate (ml/s)
+                <input id="injRate" type="range" min="0" max="10" step="0.1" value="1">
+                <span></span>
+            </label>
+            <label>Injection duration (ms)
+                <input id="injDuration" type="range" min="0" max="5000" step="100" value="1000">
+                <span></span>
+            </label>
+        </div>
+    </div>
+
+    <div class="control-section">
+        <div class="section-header">C-arm</div>
+        <div class="section-content">
+            <label>C-arm yaw
+                <input id="carmYaw" type="range" min="-180" max="180" step="1" value="0">
+                <span></span>
+            </label>
+            <label>C-arm pitch
+                <input id="carmPitch" type="range" min="-90" max="90" step="1" value="0">
+                <span></span>
+            </label>
+            <label>C-arm roll
+                <input id="carmRoll" type="range" min="-180" max="180" step="1" value="0">
+                <span></span>
+            </label>
+            <label>C-arm X
+                <input id="carmX" type="range" min="-200" max="200" step="1" value="0">
+                <span></span>
+            </label>
+            <label>C-arm Y
+                <input id="carmY" type="range" min="-200" max="200" step="1" value="0">
+                <span></span>
+            </label>
+            <label>C-arm Z
+                <input id="carmZ" type="range" min="-200" max="400" step="1" value="400">
+                <span></span>
+            </label>
+        </div>
+    </div>
+
     <button id="injectContrast">Inject</button>
     <button id="stopInjection" disabled>Stop Injection</button>
     <button id="modeToggle">Fluoroscopy</button>

--- a/simulator.js
+++ b/simulator.js
@@ -234,6 +234,16 @@ document.querySelectorAll('#controls input[type="range"]').forEach(slider => {
     update();
     slider.addEventListener('input', update);
 });
+
+// Toggle visibility of control sections
+document.querySelectorAll('.section-header').forEach(header => {
+    header.addEventListener('click', () => {
+        const content = header.nextElementSibling;
+        if (content) {
+            content.classList.toggle('hidden');
+        }
+    });
+});
 setupCArmControls(camera, vessel, cameraRadius);
 
 displayMaterial.uniforms.noiseLevel.value = parseFloat(noiseSlider.value);


### PR DESCRIPTION
## Summary
- Group guidewire, friction, imaging, injection, and C-arm controls into dedicated sections.
- Add CSS and JS to toggle control visibility via clickable headers.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae47cb26c0832eb206d6930d744e74