### PR TITLE
Render wire and contrast in black for fluoroscopy mode

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -95,7 +95,7 @@ const displayMaterial = new THREE.ShaderMaterial({
                 intensity += noise * noiseLevel;
                 intensity = clamp(intensity, 0.0, 1.0);
                 float contrast = texture2D(contrastTexture, vUv).r;
-                vec3 color = gray * (1.0 - intensity) + vec3(contrast);
+                vec3 color = gray * (1.0 - intensity) * (1.0 - contrast);
                 gl_FragColor = vec4(clamp(color, 0.0, 1.0), 1.0);
             } else {
                 gl_FragColor = tex;
@@ -280,6 +280,7 @@ modeToggle.addEventListener('click', () => {
     vesselGroup.visible = !fluoroscopy;
     displayMaterial.uniforms.fluoroscopy.value = fluoroscopy;
     modeToggle.textContent = fluoroscopy ? 'Wireframe' : 'Fluoroscopy';
+    wireMaterial.color.set(fluoroscopy ? 0x000000 : 0xffffff);
 });
 
 injectButton.addEventListener('click', () => {
@@ -300,12 +301,13 @@ stopInjectButton.addEventListener('click', () => {
     }
 });
 
-const wireMaterial = new THREE.LineBasicMaterial({color: 0xffffff});
+const wireMaterial = new THREE.LineBasicMaterial({color: 0x000000});
 const wireGeometry = new THREE.BufferGeometry();
 const wirePositions = new Float32Array(nodeCount * 3);
 wireGeometry.setAttribute('position', new THREE.BufferAttribute(wirePositions, 3));
 const wireMesh = new THREE.Line(wireGeometry, wireMaterial);
 scene.add(wireMesh);
+wireMaterial.color.set(fluoroscopy ? 0x000000 : 0xffffff);
 
 function updateWireMesh() {
     for (let i = 0; i < wire.nodes.length; i++) {
@@ -357,7 +359,7 @@ function animate(time) {
         contrastMesh = new THREE.Group();
         for (const { geometry, concentration } of contrastGeoms) {
             const material = new THREE.MeshBasicMaterial({
-                color: 0xffffff,
+                color: 0x000000,
                 transparent: true,
                 opacity: Math.min(concentration, 1)
             });


### PR DESCRIPTION
## Summary
- Render fluoroscopy display using black wire and contrast meshes
- Subtract contrast from grayscale image in fragment shader for darker contrast
- Toggle wire color when switching between modes

## Testing
- `node test.js` *(headless launch of simulator with fluoroscopy and contrast, screenshot analyzed to confirm black pixels)*


------
https://chatgpt.com/codex/tasks/task_e_68ae476251b8832e91da1a57d3cf8af9