### PR TITLE
Sync C-arm pose with preview

### DIFF
--- a/carm.js
+++ b/carm.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
+import { renderCArmPreview } from './carmPreview.js';
 
-export function setupCArmControls(camera, vessel, cameraRadius) {
+export function setupCArmControls(camera, vessel, cameraRadius, previewGroup) {
     const carmYawSlider = document.getElementById('carmYaw');
     const carmPitchSlider = document.getElementById('carmPitch');
     const carmRollSlider = document.getElementById('carmRoll');
@@ -42,6 +43,12 @@ export function setupCArmControls(camera, vessel, cameraRadius) {
         camera.up.set(0, 1, 0);
         camera.lookAt(pivot);
         camera.rotateZ(carmRoll);
+
+        if (previewGroup) {
+            previewGroup.position.copy(pivot);
+            previewGroup.rotation.set(carmPitch, carmYaw, carmRoll, 'YXZ');
+            renderCArmPreview();
+        }
     }
 
     updateCamera();

--- a/simulator.js
+++ b/simulator.js
@@ -6,7 +6,7 @@ import { ContrastAgent, getContrastGeometry } from './contrastAgent.js';
 import { PatientMonitor } from './patientMonitor.js';
 import { createCArmModel } from './carmModel.js';
 import { createOperatingTable } from './operatingTable.js';
-import { initCArmPreview, renderCArmPreview } from './carmPreview.js';
+import { initCArmPreview, cArmPreviewGroup } from './carmPreview.js';
 
 const canvas = document.getElementById('sim');
 const renderer = new THREE.WebGLRenderer({canvas, antialias: true});
@@ -234,7 +234,7 @@ document.querySelectorAll('#controls input[type="range"]').forEach(slider => {
     update();
     slider.addEventListener('input', update);
 });
-setupCArmControls(camera, vessel, cameraRadius);
+setupCArmControls(camera, vessel, cameraRadius, cArmPreviewGroup);
 
 displayMaterial.uniforms.noiseLevel.value = parseFloat(noiseSlider.value);
 noiseSlider.addEventListener('input', e => {
@@ -397,8 +397,6 @@ function animate(time) {
         renderer.setRenderTarget(null);
         renderer.render(scene, camera);
     }
-
-    renderCArmPreview();
 
     requestAnimationFrame(animate);
 }


### PR DESCRIPTION
## Summary
- Accept optional previewGroup in C-arm controls and sync its pose with camera adjustments
- Refresh C-arm miniature preview only when sliders change
- Pass cArmPreviewGroup to C-arm controls

## Testing
- `node --check carm.js`
- `node --check simulator.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae48599d68832e9a574ccb2c8de02c