### PR TITLE
Improve control section visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,10 +33,19 @@
             margin-bottom: 4px;
         }
 
+        .parameter-label {
+            font-size: 12px;
+            padding-left: 4px;
+        }
+
         .section-header {
             cursor: pointer;
             font-weight: bold;
             margin-top: 8px;
+            font-size: 16px;
+            background-color: rgba(255, 255, 255, 0.1);
+            border: 1px solid #666;
+            padding: 4px;
         }
 
         .section-content.hidden {
@@ -107,15 +116,15 @@
     <div class="control-section">
         <div class="section-header">Guidewire</div>
         <div class="section-content">
-            <label>Bending stiffness
+            <label class="parameter-label">Bending stiffness
                 <input id="stiffness" type="range" min="0" max="2" step="0.1" value="0.8">
                 <span></span>
             </label>
-            <label>Normal damping
+            <label class="parameter-label">Normal damping
                 <input id="normalDamping" type="range" min="0" max="1" step="0.01" value="0.5">
                 <span></span>
             </label>
-            <label>Velocity damping
+            <label class="parameter-label">Velocity damping
                 <input id="velocityDamping" type="range" min="0" max="1" step="0.01" value="0.98">
                 <span></span>
             </label>
@@ -125,11 +134,11 @@
     <div class="control-section">
         <div class="section-header">Friction</div>
         <div class="section-content">
-            <label>Static friction
+            <label class="parameter-label">Static friction
                 <input id="staticFriction" type="range" min="0" max="1" step="0.01" value="0.2">
                 <span></span>
             </label>
-            <label>Kinetic friction
+            <label class="parameter-label">Kinetic friction
                 <input id="kineticFriction" type="range" min="0" max="1" step="0.01" value="0.1">
                 <span></span>
             </label>
@@ -139,11 +148,11 @@
     <div class="control-section">
         <div class="section-header">Imaging</div>
         <div class="section-content">
-            <label>Persistence
+            <label class="parameter-label">Persistence
                 <input id="persistence" type="range" min="0.25" max="0.99" step="0.01" value="0.35">
                 <span></span>
             </label>
-            <label>Noise level
+            <label class="parameter-label">Noise level
                 <input id="noiseLevel" type="range" min="0" max="0.6" step="0.01" value="0.3">
             </label>
         </div>
@@ -152,11 +161,11 @@
     <div class="control-section">
         <div class="section-header">Injection</div>
         <div class="section-content">
-            <label>Injection rate (ml/s)
+            <label class="parameter-label">Injection rate (ml/s)
                 <input id="injRate" type="range" min="0" max="10" step="0.1" value="1">
                 <span></span>
             </label>
-            <label>Injection duration (ms)
+            <label class="parameter-label">Injection duration (ms)
                 <input id="injDuration" type="range" min="0" max="5000" step="100" value="1000">
                 <span></span>
             </label>
@@ -166,27 +175,27 @@
     <div class="control-section">
         <div class="section-header">C-arm</div>
         <div class="section-content">
-            <label>C-arm yaw
+            <label class="parameter-label">C-arm yaw
                 <input id="carmYaw" type="range" min="-180" max="180" step="1" value="0">
                 <span></span>
             </label>
-            <label>C-arm pitch
+            <label class="parameter-label">C-arm pitch
                 <input id="carmPitch" type="range" min="-90" max="90" step="1" value="0">
                 <span></span>
             </label>
-            <label>C-arm roll
+            <label class="parameter-label">C-arm roll
                 <input id="carmRoll" type="range" min="-180" max="180" step="1" value="0">
                 <span></span>
             </label>
-            <label>C-arm X
+            <label class="parameter-label">C-arm X
                 <input id="carmX" type="range" min="-200" max="200" step="1" value="0">
                 <span></span>
             </label>
-            <label>C-arm Y
+            <label class="parameter-label">C-arm Y
                 <input id="carmY" type="range" min="-200" max="200" step="1" value="0">
                 <span></span>
             </label>
-            <label>C-arm Z
+            <label class="parameter-label">C-arm Z
                 <input id="carmZ" type="range" min="-200" max="400" step="1" value="400">
                 <span></span>
             </label>


### PR DESCRIPTION
## Summary
- highlight control group headers with larger font, subtle background, border, and padding
- add `.parameter-label` styling and apply it to all slider labels for contrast

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4b7638a0832eb4074ac66d0b2263