### PR TITLE
Enable bidirectional contrast flow and injection controls

### DIFF
--- a/contrastAgent.js
+++ b/contrastAgent.js
@@ -1,19 +1,16 @@
 import * as THREE from 'three';
 
-// Simulates advection of a contrast agent through a vessel graph.
+// Simulates advection and dilution of a contrast agent through a vessel graph.
 export class ContrastAgent {
-    constructor(vessel, washout = 0.5) {
+    constructor(vessel, washout = 0.5, backflow = 0.2) {
         this.vessel = vessel;
         this.segments = vessel.segments;
-        this.graph = vessel.segmentGraph;
+        this.nodes = vessel.nodes || [];
         this.washout = washout;
+        this.backflow = backflow;
 
-        this.lengths = this.segments.map(s => {
-            const dx = s.end.x - s.start.x;
-            const dy = s.end.y - s.start.y;
-            const dz = s.end.z - s.start.z;
-            return Math.sqrt(dx * dx + dy * dy + dz * dz) || 1;
-        });
+        this.lengths = this.segments.map(s => s.length || 1);
+        this.volumes = this.segments.map(s => s.volume || 1);
         this.concentration = new Array(this.segments.length).fill(0);
 
         const eps = 1e-6;
@@ -27,32 +24,39 @@ export class ContrastAgent {
         if (this.sheathIndex === -1) this.sheathIndex = 0;
     }
 
-    // Adds concentration into the segment connected to the sheath.
-    inject(rate) {
-        if (this.sheathIndex >= 0) {
-            this.concentration[this.sheathIndex] += rate;
+    // Adds contrast volume into a segment (default: sheath-connected segment)
+    inject(volume, segmentIndex = this.sheathIndex) {
+        if (segmentIndex >= 0 && segmentIndex < this.concentration.length) {
+            this.concentration[segmentIndex] += volume;
         }
     }
 
     update(dt) {
         const next = new Array(this.segments.length).fill(0);
+        const nodeMass = new Array(this.nodes.length).fill(0);
         for (let i = 0; i < this.segments.length; i++) {
             const seg = this.segments[i];
             const speed = seg.flowSpeed || 0;
             const frac = Math.min(1, (speed * dt) / this.lengths[i]);
             const moved = this.concentration[i] * frac;
-            const remain = this.concentration[i] - moved;
-
-            const children = this.graph[i] || [];
-            if (children.length) {
-                let total = 0;
-                for (const c of children) total += this.segments[c].flowSpeed || 0;
-                for (const c of children) {
-                    const w = total > 0 ? (this.segments[c].flowSpeed || 0) / total : 1 / children.length;
-                    next[c] += moved * w;
-                }
+            const back = moved * this.backflow;
+            const fwd = moved - back;
+            if (seg.startNode != null) nodeMass[seg.startNode] += back;
+            if (seg.endNode != null) nodeMass[seg.endNode] += fwd;
+            next[i] += this.concentration[i] - moved;
+        }
+        // Redistribute mixed contrast from nodes to connected segments
+        for (let n = 0; n < this.nodes.length; n++) {
+            const pool = nodeMass[n];
+            if (pool <= 0) continue;
+            const segs = this.nodes[n].segments || [];
+            if (!segs.length) continue;
+            let total = 0;
+            for (const s of segs) total += this.segments[s].flowSpeed || 0;
+            for (const s of segs) {
+                const w = total > 0 ? (this.segments[s].flowSpeed || 0) / total : 1 / segs.length;
+                next[s] += pool * w;
             }
-            next[i] += remain;
         }
         const decay = Math.exp(-this.washout * dt);
         for (let i = 0; i < next.length; i++) {
@@ -66,21 +70,22 @@ export class ContrastAgent {
     }
 }
 
-// Generate TubeGeometry for segments with contrast.  The caller is
+// Generate TubeGeometry for segments with contrast. The caller is
 // responsible for assigning materials based on the returned
 // concentration value.
 export function getContrastGeometry(agent) {
     if (!agent || !agent.isActive()) return [];
     const geoms = [];
     for (let i = 0; i < agent.segments.length; i++) {
-        const c = agent.concentration[i];
-        if (c <= 1e-3) continue;
+        const amt = agent.concentration[i];
+        if (amt <= 1e-3) continue;
         const seg = agent.segments[i];
         const start = new THREE.Vector3(seg.start.x, seg.start.y, seg.start.z);
         const end = new THREE.Vector3(seg.end.x, seg.end.y, seg.end.z);
         const path = new THREE.LineCurve3(start, end);
         const geom = new THREE.TubeGeometry(path, 4, seg.radius * 0.9, 8, false);
-        geoms.push({ geometry: geom, concentration: c });
+        const conc = amt / (agent.volumes[i] || 1);
+        geoms.push({ geometry: geom, concentration: conc });
     }
     return geoms;
 }

--- a/index.html
+++ b/index.html
@@ -152,6 +152,13 @@
     <div class="control-section">
         <div class="section-header">Injection</div>
         <div class="section-content">
+            <label>Injection volume (ml)
+                <input id="injVolume" type="range" min="0" max="20" step="0.5" value="5">
+                <span></span>
+            </label>
+            <label>Injection segment
+                <select id="injSegment"></select>
+            </label>
             <label>Injection rate (ml/s)
                 <input id="injRate" type="range" min="0" max="10" step="0.1" value="1">
                 <span></span>


### PR DESCRIPTION
## Summary
- Expand vessel graph with node volumes to mix contrast at branch points
- Add advection solver with bidirectional/backflow support and segment-based injections
- Expose injection location, rate, and volume controls in the simulator UI

## Testing
- `node -e "import('./contrastAgent.js').then(()=>console.log('ok')).catch(err=>{console.error(err);process.exit(1);});"`
- `node - <<'NODE'
import { ContrastAgent } from './contrastAgent.js';

const vessel = {
  segments: [
    {start:{},end:{},radius:1,flowSpeed:30,startNode:0,endNode:1,length:10,volume:10*Math.PI},
    {start:{},end:{},radius:0.5,flowSpeed:15,startNode:1,endNode:2,length:10,volume:10*Math.PI*0.25},
    {start:{},end:{},radius:0.5,flowSpeed:15,startNode:1,endNode:3,length:10,volume:10*Math.PI*0.25}
  ],
  nodes:[
    {segments:[0]},
    {segments:[0,1,2]},
    {segments:[1]},
    {segments:[2]}
  ],
  left:{end:{x:0,y:0,z:0}}
};
const agent = new ContrastAgent(vessel);
agent.inject(5,1);
for (let t=0;t<1;t+=0.1){
  agent.update(0.1);
  console.log(t+0.1, agent.concentration.map(x=>x.toFixed(2)));
}
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68ae4ac40d8c832ea912346c20da8720