### PR TITLE
Add collapsible control sections with triangles

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,16 @@
             margin-top: 8px;
         }
 
+        .collapse-triangle {
+            display: inline-block;
+            margin-right: 4px;
+            transition: transform 0.2s;
+        }
+
+        .section-header.collapsed .collapse-triangle {
+            transform: rotate(-90deg);
+        }
+
         .section-content.hidden {
             display: none;
         }
@@ -105,7 +115,7 @@
     <div id="currentDose">0 ml</div>
 
     <div class="control-section">
-        <div class="section-header">Guidewire</div>
+        <div class="section-header"><span class="collapse-triangle">▼</span> Guidewire</div>
         <div class="section-content">
             <label>Bending stiffness
                 <input id="stiffness" type="range" min="0" max="2" step="0.1" value="0.8">
@@ -123,7 +133,7 @@
     </div>
 
     <div class="control-section">
-        <div class="section-header">Friction</div>
+        <div class="section-header"><span class="collapse-triangle">▼</span> Friction</div>
         <div class="section-content">
             <label>Static friction
                 <input id="staticFriction" type="range" min="0" max="1" step="0.01" value="0.2">
@@ -137,7 +147,7 @@
     </div>
 
     <div class="control-section">
-        <div class="section-header">Imaging</div>
+        <div class="section-header"><span class="collapse-triangle">▼</span> Imaging</div>
         <div class="section-content">
             <label>Persistence
                 <input id="persistence" type="range" min="0.25" max="0.99" step="0.01" value="0.35">
@@ -150,7 +160,7 @@
     </div>
 
     <div class="control-section">
-        <div class="section-header">Injection</div>
+        <div class="section-header"><span class="collapse-triangle">▼</span> Injection</div>
         <div class="section-content">
             <label>Injection rate (ml/s)
                 <input id="injRate" type="range" min="0" max="10" step="0.1" value="1">
@@ -164,7 +174,7 @@
     </div>
 
     <div class="control-section">
-        <div class="section-header">C-arm</div>
+        <div class="section-header"><span class="collapse-triangle">▼</span> C-arm</div>
         <div class="section-content">
             <label>C-arm yaw
                 <input id="carmYaw" type="range" min="-180" max="180" step="1" value="0">

--- a/simulator.js
+++ b/simulator.js
@@ -239,6 +239,7 @@ document.querySelectorAll('#controls input[type="range"]').forEach(slider => {
 document.querySelectorAll('.section-header').forEach(header => {
     header.addEventListener('click', () => {
         const content = header.nextElementSibling;
+        header.classList.toggle('collapsed');
         if (content) {
             content.classList.toggle('hidden');
         }


### PR DESCRIPTION
## Summary
- Prepend collapse triangle spans to each control section header for visual toggles.
- Style collapse indicator with rotation when sections are collapsed.
- Enable collapsing/expanding sections via JS click handler updating classes.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4b7736fc832e89cffe6d28630b89