### PR TITLE
Fix injection segment selection initialization order

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -129,6 +129,7 @@ vesselMesh.material.wireframe = true;
 vesselGroup.add(vesselMesh);
 scene.add(vesselGroup);
 
+const injSegmentSelect = document.getElementById('injSegment');
 // Populate injection segment choices
 if (injSegmentSelect) {
     vessel.segments.forEach((_, idx) => {
@@ -206,7 +207,6 @@ const stopInjectButton = document.getElementById('stopInjection');
 const injRateSlider = document.getElementById('injRate');
 const injDurationSlider = document.getElementById('injDuration');
 const injVolumeSlider = document.getElementById('injVolume');
-const injSegmentSelect = document.getElementById('injSegment');
 
 let injecting = false;
 let injectTime = 0;


### PR DESCRIPTION
## Summary
- Initialize injection segment dropdown before populating options
- Avoid ReferenceError in simulator.js when generating vessel segments

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4cd57f68832ea57f1b7256466578