### PR TITLE
Fix C-arm preview placement

### DIFF
--- a/carm.js
+++ b/carm.js
@@ -19,12 +19,16 @@ export function setupCArmControls(camera, vessel, cameraRadius, previewGroup) {
     ];
     sliders.forEach(s => s.addEventListener('change', () => s.blur()));
 
-    let carmYaw = 0;
-    let carmPitch = 0;
-    let carmRoll = 0;
-    let carmX = 0;
-    let carmY = -60;
-    let carmZ = 0;
+    let carmYaw = parseFloat(carmYawSlider.value) * Math.PI / 180;
+    let carmPitch = parseFloat(carmPitchSlider.value) * Math.PI / 180;
+    let carmRoll = parseFloat(carmRollSlider.value) * Math.PI / 180;
+    let carmX = parseFloat(carmXSlider.value);
+    let carmY = parseFloat(carmYSlider.value);
+    let carmZ = parseFloat(carmZSlider.value);
+
+    const initialX = carmX;
+    const initialY = carmY;
+    const initialZ = carmZ;
 
     function getPivotPoint() {
         return new THREE.Vector3(
@@ -45,7 +49,11 @@ export function setupCArmControls(camera, vessel, cameraRadius, previewGroup) {
         camera.rotateZ(carmRoll);
 
         if (previewGroup) {
-            previewGroup.position.copy(pivot);
+            previewGroup.position.set(
+                carmX - initialX,
+                carmY - initialY,
+                carmZ - initialZ
+            );
             previewGroup.rotation.set(carmPitch, carmYaw, carmRoll, 'YXZ');
             renderCArmPreview();
         }

--- a/carmModel.js
+++ b/carmModel.js
@@ -19,7 +19,8 @@ export function createCArmModel() {
 
     const gantryGeometry = new THREE.TorusGeometry(40, 3, 16, 100, Math.PI * 1.5);
     const gantry = new THREE.Mesh(gantryGeometry, material);
-    gantry.rotation.z = Math.PI / 2;
+    // Rotate the gantry so it stands vertically beside the operating table
+    gantry.rotation.set(Math.PI / 2, 0, Math.PI / 2);
     gantryGroup.add(gantry);
 
     const source = new THREE.Mesh(new THREE.BoxGeometry(8, 8, 4), material);


### PR DESCRIPTION
## Summary
- initialize C-arm control values from slider defaults
- center preview C-arm relative to initial offsets so it renders with table
- orient preview gantry vertically so C-arm model is visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4c046a90832ebcc4776dab28f3b6