### PR TITLE
Fix C-arm preview visibility

### DIFF
--- a/carmModel.js
+++ b/carmModel.js
@@ -5,16 +5,23 @@ export function createCArmModel() {
 
     const group = new THREE.Group();
 
+    // Position the base and supporting column to the side so the gantry
+    // (which is centred on the group's origin) sits over the patient/table.
     const base = new THREE.Mesh(new THREE.BoxGeometry(40, 10, 40), material);
-    base.position.y = 5;
+    base.position.set(-80, 5, 0);
     group.add(base);
 
     const column = new THREE.Mesh(new THREE.CylinderGeometry(5, 5, 60, 32), material);
-    column.position.y = 40;
+    column.position.set(-80, 40, 0);
     group.add(column);
 
+    // Simple horizontal arm connecting the column to the gantry ring
+    const arm = new THREE.Mesh(new THREE.BoxGeometry(80, 5, 5), material);
+    arm.position.set(-40, 70, 0);
+    group.add(arm);
+
     const gantryGroup = new THREE.Group();
-    gantryGroup.position.y = 70;
+    gantryGroup.position.set(0, 70, 0);
     group.add(gantryGroup);
 
     const gantryGeometry = new THREE.TorusGeometry(40, 3, 16, 100, Math.PI * 1.5);

--- a/carmPreview.js
+++ b/carmPreview.js
@@ -33,7 +33,9 @@ export function initCArmPreview() {
     container.appendChild(previewRenderer.domElement);
 
     const table = createOperatingTable();
-    table.position.y = -75; // place table so the top aligns with the origin
+    // Lower the table so the patient lies below the C-arm's isocenter
+    // making the gantry clearly visible in the preview.
+    table.position.y = -120;
     previewScene.add(table);
 
     cArmGroup = new THREE.Group();

--- a/simulator.js
+++ b/simulator.js
@@ -5,7 +5,6 @@ import { setupCArmControls } from './carm.js';
 import { ContrastAgent, getContrastGeometry } from './contrastAgent.js';
 import { PatientMonitor } from './patientMonitor.js';
 import { createCArmModel } from './carmModel.js';
-import { createOperatingTable } from './operatingTable.js';
 import { initCArmPreview, cArmPreviewGroup } from './carmPreview.js';
 
 const canvas = document.getElementById('sim');
@@ -120,7 +119,6 @@ scene.add(light);
 
 let vesselMaterial = new THREE.MeshStandardMaterial({color: 0x3366ff});
 let vesselGroup;
-let tableGroup;
 
 const { geometry, vessel } = generateVessel(140, 0); // deterministic branch parameters
 vesselGroup = new THREE.Group();
@@ -139,10 +137,6 @@ if (injSegmentSelect) {
         injSegmentSelect.appendChild(opt);
     });
 }
-
-tableGroup = createOperatingTable();
-tableGroup.position.set(vessel.branchPoint.x, -60, vessel.branchPoint.z);
-scene.add(tableGroup);
 
 const pivot = new THREE.Vector3(
     vessel.branchPoint.x,


### PR DESCRIPTION
## Summary
- Offset C-arm base and column so gantry sits over patient
- Lower operating table in preview for clearer C-arm view
- Remove operating table model from main simulation canvas

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check carmModel.js`
- `node --check carmPreview.js`
- `node --check simulator.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae4ea1e5ac832e8780ed11204dd18a