### PR TITLE
Add contrast flow demo script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/contrastFlowDemo.js
+++ b/contrastFlowDemo.js
@@ -1,0 +1,53 @@
+import { ContrastAgent } from './contrastAgent.js';
+
+// Minimal vessel with a parent segment and a distal sheath-connected segment
+const vessel = {
+  left: { end: { x: 0, y: 20, z: 0 } },
+  segments: [
+    // Parent segment (proximal)
+    {
+      start: { x: 0, y: 0, z: 0 },
+      end: { x: 0, y: 10, z: 0 },
+      radius: 2,
+      length: 10,
+      volume: Math.PI * 2 * 2 * 10,
+      startNode: 0,
+      endNode: 1,
+      flowSpeed: 5,
+      parent: null,
+    },
+    // Distal segment connected to sheath
+    {
+      start: { x: 0, y: 10, z: 0 },
+      end: { x: 0, y: 20, z: 0 },
+      radius: 2,
+      length: 10,
+      volume: Math.PI * 2 * 2 * 10,
+      startNode: 1,
+      endNode: 2,
+      flowSpeed: 5,
+      parent: 0,
+    },
+  ],
+  nodes: [
+    { position: { x: 0, y: 0, z: 0 }, segments: [0] },
+    { position: { x: 0, y: 10, z: 0 }, segments: [0, 1] },
+    { position: { x: 0, y: 20, z: 0 }, segments: [1] },
+  ],
+};
+
+const agent = new ContrastAgent(vessel);
+
+// Inject 1 ml contrast into sheath segment (index resolved internally)
+agent.inject(1);
+
+// Log concentrations for sheath and its parent over several updates
+const sheathIndex = agent.sheathIndex;
+const parentIndex = vessel.segments[sheathIndex].parent;
+
+for (let frame = 0; frame < 5; frame++) {
+  agent.update(0.1);
+  const sheathConc = agent.concentration[sheathIndex];
+  const parentConc = agent.concentration[parentIndex];
+  console.log(`Frame ${frame + 1}: sheath=${sheathConc.toFixed(3)}, parent=${parentConc.toFixed(3)}`);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "openendovasculartrainer",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "openendovasculartrainer",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "three": "^0.160.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.160.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.160.1.tgz",
+      "integrity": "sha512-Bgl2wPJypDOZ1stAxwfWAcJ0WQf7QzlptsxkjYiURPz+n5k4RBDLsq+6f9Y75TYxn6aHLcWz+JNmwTOXWrQTBQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "openendovasculartrainer",
+  "version": "1.0.0",
+  "description": "This prototype demonstrates a basic browser-based simulator for guiding a stiff wire through a branched vessel. The vessel consists of a main tube with smoothly joined side branches modeled with quadratic curves. The guidewire is now simulated with a position‑based dynamics solver that preserves segment length, adds bending stiffness, and applies tangential friction when it contacts the vessel wall, producing more realistic motion and preventing artificial shortening. The visual style mimics fluoroscopy by using a monochrome palette and persistent trail.",
+  "main": "carm.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "three": "^0.160.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add Node demo script that injects 1 ml contrast and logs sheath vs parent segment concentrations to illustrate flow splitting
- add package.json for module support and three dependency
- ignore node_modules in git

## Testing
- `node contrastFlowDemo.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae50610b94832ead46a9a7f50adce2