### PR TITLE
Add adjustable contrast opacity scale

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,6 +165,10 @@
             <label class="parameter-label">Noise level
                 <input id="noiseLevel" type="range" min="0" max="0.6" step="0.01" value="0.3">
             </label>
+            <label class="parameter-label">Contrast opacity scale
+                <input id="opacityScale" type="range" min="0" max="100" step="1" value="50">
+                <span></span>
+            </label>
         </div>
     </div>
 

--- a/simulator.js
+++ b/simulator.js
@@ -220,6 +220,7 @@ const insertedLength = document.getElementById('insertedLength');
 const doseDisplay = document.getElementById('currentDose');
 const persistenceSlider = document.getElementById('persistence');
 const noiseSlider = document.getElementById('noiseLevel');
+const opacityScaleSlider = document.getElementById('opacityScale');
 
 const sliders = [
     bendSlider,
@@ -229,6 +230,7 @@ const sliders = [
     velDampingSlider,
     persistenceSlider,
     noiseSlider,
+    opacityScaleSlider,
     injVolumeSlider,
     injRateSlider,
     injDurationSlider
@@ -259,6 +261,11 @@ setupCArmControls(camera, vessel, cameraRadius, cArmPreviewGroup);
 displayMaterial.uniforms.noiseLevel.value = parseFloat(noiseSlider.value);
 noiseSlider.addEventListener('input', e => {
     displayMaterial.uniforms.noiseLevel.value = parseFloat(e.target.value);
+});
+
+let opacityScale = parseFloat(opacityScaleSlider.value);
+opacityScaleSlider.addEventListener('input', e => {
+    opacityScale = parseFloat(e.target.value);
 });
 
 let bendingStiffness = parseFloat(bendSlider.value);
@@ -394,7 +401,7 @@ function animate(time) {
             const material = new THREE.MeshBasicMaterial({
                 color: 0xffffff,
                 transparent: true,
-                opacity: Math.min(concentration, 1)
+                opacity: Math.min(concentration * opacityScale, 1)
             });
             contrastMesh.add(new THREE.Mesh(geometry, material));
         }


### PR DESCRIPTION
## Summary
- Allow tuning contrast visibility with new opacity scale slider
- Scale contrast material opacity by configurable factor to improve visibility

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check simulator.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae515098d8832eaf9c3f15de37d8a7