### PR TITLE
Expose gantry transform in C-arm preview

### DIFF
--- a/carm.js
+++ b/carm.js
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { renderCArmPreview } from './carmPreview.js';
 
-export function setupCArmControls(camera, vessel, cameraRadius, previewGroup) {
+export function setupCArmControls(camera, vessel, cameraRadius, previewGroup, previewGantry) {
     const carmYawSlider = document.getElementById('carmYaw');
     const carmPitchSlider = document.getElementById('carmPitch');
     const carmRollSlider = document.getElementById('carmRoll');
@@ -54,7 +54,13 @@ export function setupCArmControls(camera, vessel, cameraRadius, previewGroup) {
                 carmY - initialY,
                 carmZ - initialZ
             );
-            previewGroup.rotation.set(carmPitch, carmYaw, carmRoll, 'YXZ');
+        }
+
+        if (previewGantry) {
+            previewGantry.rotation.set(carmPitch, carmYaw, carmRoll, 'YXZ');
+        }
+
+        if (previewGroup || previewGantry) {
             renderCArmPreview();
         }
     }

--- a/carmModel.js
+++ b/carmModel.js
@@ -38,6 +38,6 @@ export function createCArmModel() {
     detector.position.set(0, 0, 40);
     gantryGroup.add(detector);
 
-    return group;
+    return { group, gantryGroup };
 }
 

--- a/carmPreview.js
+++ b/carmPreview.js
@@ -6,6 +6,7 @@ let previewScene;
 let previewCamera;
 let previewRenderer;
 let cArmGroup;
+let cArmGantry;
 
 export function initCArmPreview() {
     const container = document.getElementById('carm-preview');
@@ -39,7 +40,8 @@ export function initCArmPreview() {
     previewScene.add(table);
 
     cArmGroup = new THREE.Group();
-    const cArm = createCArmModel();
+    const { group: cArm, gantryGroup } = createCArmModel();
+    cArmGantry = gantryGroup;
     cArm.position.y = -70; // align gantry center with the group's origin
     cArmGroup.add(cArm);
     previewScene.add(cArmGroup);
@@ -53,4 +55,9 @@ export function renderCArmPreview() {
     previewRenderer.render(previewScene, previewCamera);
 }
 
-export { previewScene as cArmPreviewScene, previewCamera as cArmPreviewCamera, cArmGroup as cArmPreviewGroup };
+export {
+    previewScene as cArmPreviewScene,
+    previewCamera as cArmPreviewCamera,
+    cArmGroup as cArmPreviewGroup,
+    cArmGantry as cArmPreviewGantry
+};

--- a/simulator.js
+++ b/simulator.js
@@ -4,8 +4,7 @@ import { generateVessel } from './vesselGeometry.js';
 import { setupCArmControls } from './carm.js';
 import { ContrastAgent, getContrastGeometry } from './contrastAgent.js';
 import { PatientMonitor } from './patientMonitor.js';
-import { createCArmModel } from './carmModel.js';
-import { initCArmPreview, cArmPreviewGroup } from './carmPreview.js';
+import { initCArmPreview, cArmPreviewGroup, cArmPreviewGantry } from './carmPreview.js';
 
 const canvas = document.getElementById('sim');
 const renderer = new THREE.WebGLRenderer({canvas, antialias: true});
@@ -254,7 +253,7 @@ document.querySelectorAll('.section-header').forEach(header => {
         }
     });
 });
-setupCArmControls(camera, vessel, cameraRadius, cArmPreviewGroup);
+setupCArmControls(camera, vessel, cameraRadius, cArmPreviewGroup, cArmPreviewGantry);
 
 displayMaterial.uniforms.noiseLevel.value = parseFloat(noiseSlider.value);
 noiseSlider.addEventListener('input', e => {


### PR DESCRIPTION
## Summary
- Return both the C-arm root group and its gantry group from `createCArmModel`
- Export a `cArmPreviewGantry` reference from the preview to control rotations
- Apply yaw/pitch/roll to the gantry only and pass the reference through `setupCArmControls`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae51afa738832ea74c06f33ca12c3f