### PR TITLE
Use axis-specific rotation for C-arm gantry controls

### DIFF
--- a/carm.js
+++ b/carm.js
@@ -57,7 +57,10 @@ export function setupCArmControls(camera, vessel, cameraRadius, previewGroup, pr
         }
 
         if (previewGantry) {
-            previewGantry.rotation.set(carmPitch, carmYaw, carmRoll, 'YXZ');
+            previewGantry.rotation.set(0, 0, 0);
+            previewGantry.rotateY(carmYaw);
+            previewGantry.rotateX(carmPitch);
+            previewGantry.rotateZ(carmRoll);
         }
 
         if (previewGroup || previewGantry) {


### PR DESCRIPTION
## Summary
- Replace combined gantry rotation with explicit yaw, pitch, and roll rotations
- Ensure C-arm sliders only affect their intended axis

## Testing
- `node testRotation.mjs` *(manual script)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae529ea9f8832e894248aaebf06a1e