### PR TITLE
Support injecting contrast at segment end nodes

### DIFF
--- a/contrastAgent.js
+++ b/contrastAgent.js
@@ -25,12 +25,15 @@ export class ContrastAgent {
         if (this.sheathIndex === -1) this.sheathIndex = 0;
     }
 
-    // Adds contrast volume into a segment (default: sheath-connected segment)
-    inject(volume, segmentIndex = this.sheathIndex) {
+    // Adds contrast volume into a segment (default: sheath-connected segment).
+    // By default, the contrast is injected at the segment's end node. Pass
+    // `atEnd = false` to inject at the start node instead.
+    inject(volume, segmentIndex = this.sheathIndex, atEnd = true) {
         if (segmentIndex >= 0 && segmentIndex < this.segments.length) {
             const seg = this.segments[segmentIndex];
-            if (seg.startNode != null) {
-                this.pendingNodeMass[seg.startNode] += volume;
+            const node = atEnd ? seg.endNode : seg.startNode;
+            if (node != null) {
+                this.pendingNodeMass[node] += volume;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Allow contrast injection to target segment end nodes by default
- Add optional `atEnd` parameter to inject at the start node when needed
- Adjust mass accumulation to use the selected node

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5321cffc832e84753c586eadcf00