### PR TITLE
Add contrast debug logging and UI toggle

### DIFF
--- a/contrastAgent.js
+++ b/contrastAgent.js
@@ -2,12 +2,13 @@ import * as THREE from 'three';
 
 // Simulates advection and dilution of a contrast agent through a vessel graph.
 export class ContrastAgent {
-    constructor(vessel, washout = 0.5, backflow = 0.2) {
+    constructor(vessel, washout = 0.5, backflow = 0.2, debug = false) {
         this.vessel = vessel;
         this.segments = vessel.segments;
         this.nodes = vessel.nodes || [];
         this.washout = washout;
         this.backflow = backflow;
+        this.debug = debug;
 
         this.lengths = this.segments.map(s => s.length || 1);
         this.volumes = this.segments.map(s => s.volume || 1);
@@ -71,6 +72,12 @@ export class ContrastAgent {
             next[i] *= decay;
         }
         this.concentration = next;
+        if (this.debug) {
+            const masses = this.concentration
+                .map((m, i) => `Seg ${i}: ${m.toFixed(4)}`)
+                .join(', ');
+            console.log(`Contrast masses: ${masses}`);
+        }
     }
 
     isActive() {

--- a/simulator.js
+++ b/simulator.js
@@ -155,8 +155,22 @@ const pivot = new THREE.Vector3(
 const contrast = new ContrastAgent(vessel);
 let contrastMesh = null;
 
+// Debug toggle to log contrast information
+const debugLabel = document.createElement('label');
+debugLabel.style.display = 'block';
+const debugCheckbox = document.createElement('input');
+debugCheckbox.type = 'checkbox';
+debugCheckbox.id = 'debugToggle';
+debugLabel.appendChild(debugCheckbox);
+debugLabel.appendChild(document.createTextNode(' Debug contrast'));
+document.getElementById('controls').appendChild(debugLabel);
+debugCheckbox.addEventListener('change', e => {
+    contrast.debug = e.target.checked;
+});
+
 // Default to sheath injection and hide the segment selector
 const sheathIndex = contrast.sheathIndex;
+const parentIndex = sheathIndex > 0 ? sheathIndex - 1 : -1;
 if (injSegmentSelect) {
     injSegmentSelect.value = sheathIndex;
     injSegmentSelect.parentElement.style.display = 'none';
@@ -398,6 +412,11 @@ function animate(time) {
         }
     }
     contrast.update(dt);
+    if (contrast.debug) {
+        const sheathConc = contrast.concentration[sheathIndex] / (contrast.volumes[sheathIndex] || 1);
+        const parentConc = parentIndex >= 0 ? contrast.concentration[parentIndex] / (contrast.volumes[parentIndex] || 1) : 0;
+        console.log(`Sheath conc: ${sheathConc.toFixed(4)}, Parent conc: ${parentConc.toFixed(4)}`);
+    }
     if (contrastMesh) {
         scene.remove(contrastMesh);
         contrastMesh = null;


### PR DESCRIPTION
## Summary
- add optional `debug` flag to `ContrastAgent` that logs per-segment masses after each update
- add checkbox in simulator to toggle contrast debugging and report sheath/parent concentrations each frame

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node --input-type=module <script>` (manual contrast update: shows mass advection)


------
https://chatgpt.com/codex/tasks/task_e_68ae542c27d8832eb48b4aa1721141cf