### PR TITLE
Orient C-arm toward patient in neutral pose

### DIFF
--- a/carmModel.js
+++ b/carmModel.js
@@ -24,19 +24,27 @@ export function createCArmModel() {
     gantryGroup.position.set(0, 70, 0);
     group.add(gantryGroup);
 
+    // Internal group orienting the gantry so the X-ray beam points toward
+    // the negative Y-axis when no additional rotations are applied.
+    const gantryModel = new THREE.Group();
+    gantryModel.rotation.x = Math.PI / 2;
+    gantryGroup.add(gantryModel);
+
     const gantryGeometry = new THREE.TorusGeometry(40, 3, 16, 100, Math.PI * 1.5);
     const gantry = new THREE.Mesh(gantryGeometry, material);
-    // Rotate the gantry so it stands vertically beside the operating table
-    gantry.rotation.set(Math.PI / 2, 0, Math.PI / 2);
-    gantryGroup.add(gantry);
+    // Rotate so the open side of the torus faces the patient.
+    gantry.rotation.z = Math.PI / 2;
+    gantryModel.add(gantry);
 
+    // Position the source below and the detector above the isocenter so the
+    // detector (intensifier) faces downward along the -Y axis.
     const source = new THREE.Mesh(new THREE.BoxGeometry(8, 8, 4), material);
-    source.position.set(0, 0, -40);
-    gantryGroup.add(source);
+    source.position.set(0, 0, 40);
+    gantryModel.add(source);
 
     const detector = new THREE.Mesh(new THREE.BoxGeometry(8, 8, 4), material);
-    detector.position.set(0, 0, 40);
-    gantryGroup.add(detector);
+    detector.position.set(0, 0, -40);
+    gantryModel.add(detector);
 
     return { group, gantryGroup };
 }

--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@
                 <span></span>
             </label>
             <label class="parameter-label">C-arm Z
-                <input id="carmZ" type="range" min="-200" max="400" step="1" value="400">
+                <input id="carmZ" type="range" min="-200" max="400" step="1" value="0">
                 <span></span>
             </label>
         </div>


### PR DESCRIPTION
## Summary
- Rotate internal gantry so the C-arm's torus, source, and detector aim down the negative Y-axis when yaw/pitch/roll are zero
- Default C-arm Z slider to 0 so the intensifier targets the patient in the neutral position

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae53d48994832eba66977443ac7a2f