### PR TITLE
Render bones additively and keep guidewire visible

### DIFF
--- a/boneModel.js
+++ b/boneModel.js
@@ -1,8 +1,14 @@
 import * as THREE from 'three';
 
 export function createBoneModel() {
-    // Use a white material so bones appear bright in fluoroscopy rendering
-    const material = new THREE.MeshStandardMaterial({ color: 0xffffff });
+    // Use additive blending so bones brighten underlying geometry without occluding it
+    const material = new THREE.MeshStandardMaterial({
+        color: 0xffffff,
+        transparent: true,
+        depthWrite: false,
+        depthTest: false,
+        blending: THREE.AdditiveBlending
+    });
     const group = new THREE.Group();
 
     // Approximate pelvis using two hip boxes and a central sacrum

--- a/simulator.js
+++ b/simulator.js
@@ -352,11 +352,15 @@ stopInjectButton.addEventListener('click', () => {
 });
 
 // Use a white guidewire so the fluoroscopy shader can invert it to black.
-const wireMaterial = new THREE.LineBasicMaterial({color: 0xffffff});
+const wireMaterial = new THREE.LineBasicMaterial({
+    color: 0xffffff,
+    depthTest: false
+});
 const wireGeometry = new THREE.BufferGeometry();
 const wirePositions = new Float32Array(nodeCount * 3);
 wireGeometry.setAttribute('position', new THREE.BufferAttribute(wirePositions, 3));
 const wireMesh = new THREE.Line(wireGeometry, wireMaterial);
+wireMesh.renderOrder = 1; // draw on top of additive bone rendering
 scene.add(wireMesh);
 
 function updateWireMesh() {


### PR DESCRIPTION
## Summary
- Render bone meshes with additive blending and disabled depth writes/tests so they don't obscure other geometry
- Disable depth testing and raise render order for guidewire line so it appears over bones

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae54cff660832e8e298f1e818d68f9