### PR TITLE
Add channel-based fluoroscopy attenuation

### DIFF
--- a/boneModel.js
+++ b/boneModel.js
@@ -1,8 +1,8 @@
 import * as THREE from 'three';
 
 export function createBoneModel() {
-    // Use a white material so bones appear bright in fluoroscopy rendering
-    const material = new THREE.MeshStandardMaterial({ color: 0xffffff });
+    // Render bones into the red channel for fluoroscopy attenuation
+    const material = new THREE.MeshBasicMaterial({ color: 0xff0000 });
     const group = new THREE.Group();
 
     // Approximate pelvis using two hip boxes and a central sacrum


### PR DESCRIPTION
## Summary
- Separate bone, vessel contrast, and guidewire into red, green, and blue channels for fluoroscopy
- Add `wireOpacity` uniform and implement multiplicative attenuation in fragment shader

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae54bf33ec832eab5e5d3adb11d429