### PR TITLE
Reduce bone visibility and move bones behind vessels

### DIFF
--- a/boneModel.js
+++ b/boneModel.js
@@ -5,8 +5,9 @@ export function createBoneModel() {
     const material = new THREE.MeshStandardMaterial({
         color: 0xffffff,
         transparent: true,
+        opacity: 0.5, // reduce brightness so bones are less dominant
         depthWrite: false,
-        depthTest: false,
+        depthTest: false, // rely on render order so vessels draw on top
         blending: THREE.AdditiveBlending
     });
     const group = new THREE.Group();

--- a/simulator.js
+++ b/simulator.js
@@ -68,7 +68,8 @@ const displayMaterial = new THREE.ShaderMaterial({
         fluoroscopy: { value: false },
         time: { value: 0 },
         noiseLevel: { value: 0.05 },
-        boneOpacity: { value: 1.0 }
+        // Lower default bone opacity so bones appear less prominent
+        boneOpacity: { value: 0.5 }
 
     },
     vertexShader: `
@@ -133,8 +134,9 @@ scene.add(vesselGroup);
 boneGroup.position.set(
     vessel.branchPoint.x,
     vessel.branchPoint.y - 60,
-    vessel.branchPoint.z
+    vessel.branchPoint.z - 50 // push bones back so they render behind vessels
 );
+boneGroup.renderOrder = -1; // ensure bones draw before vessel geometry
 scene.add(boneGroup);
 
 const injSegmentSelect = document.getElementById('injSegment');


### PR DESCRIPTION
## Summary
- disable depth testing on bone material and rely on render order for vessel overlay
- offset bones and render earlier so vessel geometry appears in front

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae573909d0832eb1d26c08551c91c4