### PR TITLE
Subdivide contrast geometry and add vertex colors

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -432,13 +432,13 @@ function animate(time) {
     const contrastGeoms = getContrastGeometry(contrast);
     if (contrastGeoms.length) {
         contrastMesh = new THREE.Group();
-        for (const { geometry, concentration } of contrastGeoms) {
-            const material = new THREE.MeshBasicMaterial({
-                color: 0xffffff,
-                transparent: true,
-                opacity: Math.min(concentration * opacityScale, 1)
-            });
-            contrastMesh.add(new THREE.Mesh(geometry, material));
+        const material = new THREE.MeshBasicMaterial({
+            vertexColors: true,
+            transparent: true,
+            opacity: Math.min(opacityScale / 100, 1)
+        });
+        for (const geom of contrastGeoms) {
+            contrastMesh.add(new THREE.Mesh(geom, material));
         }
         scene.add(contrastMesh);
     }


### PR DESCRIPTION
## Summary
- Subdivide vessel segments into per-sample tube geometries with vertex colors encoding contrast concentration
- Optionally merge geometries for efficient rendering and update simulator to consume new geometry format

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae59086634832e8553faa08c32c483