### PR TITLE
Add BufferGeometryUtils import mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,7 +246,8 @@
 {
     "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
-        "three-mesh-bvh": "https://cdn.jsdelivr.net/npm/three-mesh-bvh@0.7.5/build/index.module.js"
+        "three-mesh-bvh": "https://cdn.jsdelivr.net/npm/three-mesh-bvh@0.7.5/build/index.module.js",
+        "three/examples/jsm/utils/BufferGeometryUtils.js": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/utils/BufferGeometryUtils.js"
     }
 }
 </script>


### PR DESCRIPTION
## Summary
- Map `three/examples/jsm/utils/BufferGeometryUtils.js` to jsDelivr so the contrast agent module loads in the browser

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5b46446c832eabf7e46da574bcbc