### PR TITLE
Add configurable guidewire smoothing parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,6 +138,14 @@
                 <input id="velocityDamping" type="range" min="0" max="1" step="0.01" value="0.98">
                 <span></span>
             </label>
+            <label class="parameter-label">Smoothing iterations
+                <input id="smoothIterations" type="range" min="0" max="10" step="1" value="1">
+                <span></span>
+            </label>
+            <label class="parameter-label">Smoothing alpha
+                <input id="smoothAlpha" type="range" min="0" max="1" step="0.01" value="0.5">
+                <span></span>
+            </label>
         </div>
     </div>
 

--- a/physics/guidewire.js
+++ b/physics/guidewire.js
@@ -9,6 +9,10 @@ let advanceForce = 100;
 // Global velocity damping applied each integrate step
 let velocityDamping = 0.98;
 
+// Parameters controlling Laplacian smoothing
+let smoothingIterations = 1;
+let smoothingAlpha = 0.5;
+
 // Allow configuration from the outside
 export function setWallFriction(staticCoeff, kineticCoeff) {
     wallStaticFriction = staticCoeff;
@@ -25,6 +29,11 @@ export function setAdvanceForce(value) {
 
 export function setVelocityDamping(value) {
     velocityDamping = value;
+}
+
+export function setSmoothingParameters(iterations, alpha) {
+    smoothingIterations = iterations;
+    smoothingAlpha = alpha;
 }
 
 function clamp(v, min, max) {
@@ -356,17 +365,19 @@ export class Guidewire {
     }
 
     // Laplacian smoothing to limit sharp kinks
-    smooth() {
-        for (let i = 1; i < this.nodes.length - 1; i++) {
-            const prev = this.nodes[i - 1];
-            const curr = this.nodes[i];
-            const next = this.nodes[i + 1];
-            const avgx = (prev.x + next.x) * 0.5;
-            const avgy = (prev.y + next.y) * 0.5;
-            const avgz = (prev.z + next.z) * 0.5;
-            curr.x += (avgx - curr.x) * 0.5;
-            curr.y += (avgy - curr.y) * 0.5;
-            curr.z += (avgz - curr.z) * 0.5;
+    smooth(iterations = smoothingIterations, alpha = smoothingAlpha) {
+        for (let k = 0; k < iterations; k++) {
+            for (let i = 1; i < this.nodes.length - 1; i++) {
+                const prev = this.nodes[i - 1];
+                const curr = this.nodes[i];
+                const next = this.nodes[i + 1];
+                const avgx = (prev.x + next.x) * 0.5;
+                const avgy = (prev.y + next.y) * 0.5;
+                const avgz = (prev.z + next.z) * 0.5;
+                curr.x += (avgx - curr.x) * alpha;
+                curr.y += (avgy - curr.y) * alpha;
+                curr.z += (avgz - curr.z) * alpha;
+            }
         }
     }
 

--- a/simulator.js
+++ b/simulator.js
@@ -1,5 +1,5 @@
 import * as THREE from 'three';
-import { Guidewire, setBendingStiffness, setWallFriction, setNormalDamping, setVelocityDamping } from './physics/guidewire.js';
+import { Guidewire, setBendingStiffness, setWallFriction, setNormalDamping, setVelocityDamping, setSmoothingParameters } from './physics/guidewire.js';
 import { generateVessel } from './vesselGeometry.js';
 import { setupCArmControls } from './carm.js';
 import { ContrastAgent, getContrastGeometry } from './contrastAgent.js';
@@ -228,6 +228,8 @@ const staticFricSlider = document.getElementById('staticFriction');
 const kineticFricSlider = document.getElementById('kineticFriction');
 const dampingSlider = document.getElementById('normalDamping');
 const velDampingSlider = document.getElementById('velocityDamping');
+const smoothIterSlider = document.getElementById('smoothIterations');
+const smoothAlphaSlider = document.getElementById('smoothAlpha');
 const modeToggle = document.getElementById('modeToggle');
 const injectButton = document.getElementById('injectContrast');
 const stopInjectButton = document.getElementById('stopInjection');
@@ -254,6 +256,8 @@ const sliders = [
     kineticFricSlider,
     dampingSlider,
     velDampingSlider,
+    smoothIterSlider,
+    smoothAlphaSlider,
     persistenceSlider,
     noiseSlider,
     opacityScaleSlider,
@@ -342,9 +346,12 @@ let kineticFriction = parseFloat(kineticFricSlider.value);
 let normalDamping = parseFloat(dampingSlider.value);
 let velocityDamping = parseFloat(velDampingSlider.value);
 let decay = parseFloat(persistenceSlider.value);
+let smoothingIterations = parseInt(smoothIterSlider.value);
+let smoothingAlpha = parseFloat(smoothAlphaSlider.value);
 setWallFriction(staticFriction, kineticFriction);
 setNormalDamping(normalDamping);
 setVelocityDamping(velocityDamping);
+setSmoothingParameters(smoothingIterations, smoothingAlpha);
 blendMaterial.uniforms.decay.value = decay;
 staticFricSlider.addEventListener('input', e => {
     staticFriction = parseFloat(e.target.value);
@@ -361,6 +368,14 @@ dampingSlider.addEventListener('input', e => {
 velDampingSlider.addEventListener('input', e => {
     velocityDamping = parseFloat(e.target.value);
     setVelocityDamping(velocityDamping);
+});
+smoothIterSlider.addEventListener('input', e => {
+    smoothingIterations = parseInt(e.target.value);
+    setSmoothingParameters(smoothingIterations, smoothingAlpha);
+});
+smoothAlphaSlider.addEventListener('input', e => {
+    smoothingAlpha = parseFloat(e.target.value);
+    setSmoothingParameters(smoothingIterations, smoothingAlpha);
 });
 persistenceSlider.addEventListener('input', e => {
     blendMaterial.uniforms.decay.value = parseFloat(e.target.value);


### PR DESCRIPTION
## Summary
- Make guidewire smoothing configurable via iteration count and relaxation factor
- Expose a `setSmoothingParameters` helper and new UI sliders for tuning

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5c5a9d74832e831f1212068a1114