### PR TITLE
Handle wire collisions before final constraint pass

### DIFF
--- a/physics/guidewire.js
+++ b/physics/guidewire.js
@@ -402,8 +402,9 @@ export class Guidewire {
         this.accumulateForces();
         this.integrate(dt);
         this.solvePbd();
-        this.smooth();
         this.collide();
+        this.solvePbd();
+        this.smooth();
         for (let i = 0; i < this.nodes.length - 1; i++) {
             const n = this.nodes[i];
             n.vx = (n.x - n.oldx) / dt;


### PR DESCRIPTION
## Summary
- Resolve guidewire collisions before the final constraint solving step and smooth after all constraints

## Testing
- `node -e "import {Guidewire} from './physics/guidewire.js'; const vessel = {branchPoint:{x:0,y:0,z:0}, left:{end:{x:-10,y:0,z:0}}, right:{end:{x:10,y:0,z:0}}, sheath:{start:{x:0,y:0,z:0}, end:{x:-1,y:0,z:0}, radius:1}, segments:[{start:{x:0,y:0,z:0}, end:{x:10,y:0,z:0}, radius:1}]}; const wire = new Guidewire(1,5,{x:0,y:0,z:0},{x:1,y:0,z:0},vessel, undefined, undefined, undefined, undefined, {left:true}); wire.nodes[0].y=2; wire.nodes[1].y=1.5; wire.nodes[2].y=1; console.log('before', wire.nodes.map(n=>n.y)); for(let i=0;i<50;i++){ wire.step(0.016,-0.5); } console.log('after', wire.nodes.map(n=>n.y));"`
- `npm test >/tmp/test.log || true`
- `cat /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68ae5f648eac832ea644a299aaa4d10d