### PR TITLE
Clamp timestep after tab inactivity

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -458,8 +458,13 @@ function withTransparentClear(renderer, fn) {
 }
 
 function animate(time) {
-    const dt = (time - lastTime) / 1000;
+    let dt = (time - lastTime) / 1000;
     lastTime = time;
+    // When the tab is inactive, requestAnimationFrame pauses. The next
+    // frame reports a very large time delta which caused the patient monitor
+    // graphs to jump or flatline when returning. Clamp the timestep so we
+    // only advance the simulation by a reasonable amount each frame.
+    dt = Math.min(dt, 0.1);
 
     // Accumulate time and step the physics at a fixed rate.
     accumulator += Math.min(dt, fixedDt * maxSubSteps);


### PR DESCRIPTION
## Summary
- prevent runaway ECG and blood pressure waveforms when switching away from the tab by clamping the animation timestep

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6366488c832ea9153bdfb24f3af1