### PR TITLE
Adjust C-arm preview yaw/pitch axes

### DIFF
--- a/carm.js
+++ b/carm.js
@@ -58,9 +58,12 @@ export function setupCArmControls(camera, vessel, cameraRadius, previewGroup, pr
 
         if (previewGantry) {
             previewGantry.rotation.set(0, 0, 0);
-            previewGantry.rotateY(carmYaw);
+            // Yaw: lean toward patient's sides (rotate around Z)
+            previewGantry.rotateZ(carmYaw);
+            // Pitch: tilt toward head or feet (rotate around X)
             previewGantry.rotateX(carmPitch);
-            previewGantry.rotateZ(carmRoll);
+            // Roll: spin around vertical axis
+            previewGantry.rotateY(carmRoll);
         }
 
         if (previewGroup || previewGantry) {


### PR DESCRIPTION
## Summary
- Re-map C-arm preview rotations so yaw tilts toward patient sides and pitch toward head/feet
- Rotate roll about vertical axis to accommodate new yaw/pitch mapping

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae63fdd294832ead5e06ab1d444143