### PR TITLE
Add gain parameter for contrast rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,6 +177,10 @@
                 <input id="opacityScale" type="range" min="0" max="100" step="1" value="50">
                 <span></span>
             </label>
+            <label class="parameter-label">Contrast gain
+                <input id="gain" type="range" min="0" max="5" step="0.1" value="1">
+                <span></span>
+            </label>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Add gain slider and uniform to control nonlinear contrast agent intensity.
- Render contrast alpha directly in display shader with slight amplification.

## Testing
- `node --check simulator.js && echo 'syntax OK'`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af0907b9fc832e8a977f220457afbe