### PR TITLE
Inject contrast into main vessel and boost default dose

### DIFF
--- a/contrastAgent.js
+++ b/contrastAgent.js
@@ -22,14 +22,15 @@ export class ContrastAgent {
             Math.abs(a.x - b.x) < eps &&
             Math.abs(a.y - b.y) < eps &&
             Math.abs(a.z - b.z) < eps;
-        const sheathNode = vessel.sheath ? vessel.sheath.end : vessel.left.end;
+        // Default to injecting into the main vessel segment rather than a branch
+        const mainNode = vessel.main ? vessel.main.start : this.segments[0].start;
         this.sheathIndex = this.segments.findIndex(
-            s => sheathNode && equal(s.start, sheathNode)
+            s => mainNode && equal(s.start, mainNode)
         );
         if (this.sheathIndex === -1) this.sheathIndex = 0;
     }
 
-    // Adds contrast volume into a segment (default: sheath-connected segment).
+    // Adds contrast volume into a segment (default: main vessel segment).
     // By default, the contrast is injected at the segment's start node. Pass
     // `atEnd = true` to inject at the end node instead.
     inject(volume, segmentIndex = this.sheathIndex, atEnd = false, spread = 1, injectionSpeed = null) {

--- a/contrastFlowDemo.js
+++ b/contrastFlowDemo.js
@@ -1,6 +1,6 @@
 import { ContrastAgent } from './contrastAgent.js';
 
-// Minimal vessel with a parent segment and a distal sheath-connected segment
+// Minimal vessel with a parent segment and a distal branch segment
 const vessel = {
   left: { end: { x: 0, y: 20, z: 0 } },
   segments: [
@@ -16,7 +16,7 @@ const vessel = {
       flowSpeed: 5,
       parent: null,
     },
-    // Distal segment connected to sheath
+    // Distal segment
     {
       start: { x: 0, y: 10, z: 0 },
       end: { x: 0, y: 20, z: 0 },
@@ -38,16 +38,16 @@ const vessel = {
 
 const agent = new ContrastAgent(vessel);
 
-// Inject 1 ml contrast into sheath segment (index resolved internally)
+// Inject 1 ml contrast into the main segment (index resolved internally)
 agent.inject(1);
 
-// Log concentrations for sheath and its parent over several updates
-const sheathIndex = agent.sheathIndex;
-const parentIndex = vessel.segments[sheathIndex].parent;
+// Log concentrations for the main segment and its child over several updates
+const mainIndex = agent.sheathIndex;
+const childIndex = 1; // only child segment in this demo
 
 for (let frame = 0; frame < 5; frame++) {
   agent.update(0.1);
-  const sheathConc = agent.concentration[sheathIndex];
-  const parentConc = agent.concentration[parentIndex];
-  console.log(`Frame ${frame + 1}: sheath=${sheathConc.toFixed(3)}, parent=${parentConc.toFixed(3)}`);
+  const mainConc = agent.concentration[mainIndex];
+  const childConc = agent.concentration[childIndex];
+  console.log(`Frame ${frame + 1}: main=${mainConc.toFixed(3)}, child=${childConc.toFixed(3)}`);
 }

--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@
         <div class="section-header"><span class="collapse-triangle">▼</span> Injection</div>
         <div class="section-content">
             <label>Injection volume (ml)
-                <input id="injVolume" type="range" min="0" max="20" step="0.5" value="5">
+                <input id="injVolume" type="range" min="0" max="20" step="0.5" value="10">
                 <span></span>
             </label>
             <label>Injection segment
@@ -196,11 +196,11 @@
             </label>
 
             <label class="parameter-label">Injection rate (ml/s)
-                <input id="injRate" type="range" min="0" max="10" step="0.1" value="1">
+                <input id="injRate" type="range" min="0" max="10" step="0.1" value="2">
                 <span></span>
             </label>
             <label class="parameter-label">Injection duration (ms)
-                <input id="injDuration" type="range" min="0" max="5000" step="100" value="1000">
+                <input id="injDuration" type="range" min="0" max="5000" step="100" value="2000">
                 <span></span>
             </label>
         </div>

--- a/simulator.js
+++ b/simulator.js
@@ -177,11 +177,11 @@ debugCheckbox.addEventListener('change', e => {
     contrast.debug = e.target.checked;
 });
 
-// Default to sheath injection and hide the segment selector
-const sheathIndex = contrast.sheathIndex;
-const parentIndex = sheathIndex > 0 ? sheathIndex - 1 : -1;
+// Default to injecting into the main vessel and hide the segment selector
+const injectSegmentIndex = contrast.sheathIndex;
+const parentIndex = injectSegmentIndex > 0 ? injectSegmentIndex - 1 : -1;
 if (injSegmentSelect) {
-    injSegmentSelect.value = sheathIndex;
+    injSegmentSelect.value = injectSegmentIndex;
     injSegmentSelect.parentElement.style.display = 'none';
 }
 
@@ -244,9 +244,9 @@ const injVolumeSlider = document.getElementById('injVolume');
 
 let injecting = false;
 let injectTime = 0;
-let injectDuration = 1; // seconds
-let injectRate = 1; // ml per second
-let injectVolume = 0; // total ml
+let injectDuration = 2; // seconds
+let injectRate = 2; // ml per second
+let injectVolume = 10; // total ml
 let remainingVolume = 0;
 let totalDose = 0;
 const insertedLength = document.getElementById('insertedLength');
@@ -487,7 +487,7 @@ function animate(time) {
     updateWireMesh();
     if (injecting) {
         const amt = Math.min(injectRate * dt, remainingVolume);
-        contrast.inject(amt, sheathIndex, false);
+        contrast.inject(amt, injectSegmentIndex, false);
         totalDose += amt;
         doseDisplay.textContent = totalDose.toFixed(1) + ' ml';
         injectTime += dt;
@@ -499,9 +499,9 @@ function animate(time) {
     }
     contrast.update(dt);
     if (contrast.debug) {
-        const sheathConc = contrast.concentration[sheathIndex] / (contrast.volumes[sheathIndex] || 1);
+        const mainConc = contrast.concentration[injectSegmentIndex] / (contrast.volumes[injectSegmentIndex] || 1);
         const parentConc = parentIndex >= 0 ? contrast.concentration[parentIndex] / (contrast.volumes[parentIndex] || 1) : 0;
-        console.log(`Sheath conc: ${sheathConc.toFixed(4)}, Parent conc: ${parentConc.toFixed(4)}`);
+        console.log(`Main conc: ${mainConc.toFixed(4)}, Parent conc: ${parentConc.toFixed(4)}`);
     }
     if (contrastMesh) {
         scene.remove(contrastMesh);


### PR DESCRIPTION
## Summary
- Direct contrast injections into main vessel segment instead of branch.
- Increase default injection volume, rate and duration for higher initial contrast dosing.
- Update demo and UI to reflect main-vessel injection.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af0af05158832eb63f3a836dbb3761