### PR TITLE
Dispose contrast mesh resources before removal

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -505,6 +505,14 @@ function animate(time) {
         console.log(`Main conc: ${mainConc.toFixed(4)}, Parent conc: ${parentConc.toFixed(4)}`);
     }
     if (contrastMesh) {
+        contrastMesh.traverse(child => {
+            if (child.isMesh) {
+                if (child.geometry) child.geometry.dispose();
+                if (child.material && child.material !== contrastMaterial) {
+                    child.material.dispose();
+                }
+            }
+        });
         scene.remove(contrastMesh);
         contrastScene.remove(contrastMesh);
         contrastMesh = null;


### PR DESCRIPTION
## Summary
- free contrast mesh resources by disposing child geometries and non-shared materials
- remove contrast mesh group from both `scene` and `contrastScene`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af1364fb50832e94cf13567c2cd874