### PR TITLE
Preallocate and reuse contrast concentration buffers

### DIFF
--- a/contrastAgent.js
+++ b/contrastAgent.js
@@ -20,6 +20,8 @@ export class ContrastAgent {
         this.lengths = this.segments.map(s => s.length || 1);
         this.volumes = this.segments.map(s => s.volume || 1);
         this.concentration = this.segments.map(() => new Array(this.samplesPerSegment).fill(0));
+        // Preallocate next concentration buffers so we can reuse them each frame
+        this.next = this.segments.map(() => new Array(this.samplesPerSegment).fill(0));
         this.pendingNodeMass = new Array(this.nodes.length).fill(0);
 
         const eps = 1e-6;
@@ -80,7 +82,10 @@ export class ContrastAgent {
     }
 
     update(dt) {
-        const next = this.segments.map(() => new Array(this.samplesPerSegment).fill(0));
+        const next = this.next;
+        for (let i = 0; i < next.length; i++) {
+            next[i].fill(0);
+        }
         const nodeMass = this.pendingNodeMass.slice();
         this.pendingNodeMass.fill(0);
         for (let i = 0; i < this.segments.length; i++) {
@@ -151,7 +156,11 @@ export class ContrastAgent {
                 next[i][j] *= decay;
             }
         }
+
+        // Swap concentration buffers to avoid reallocating arrays
+        const current = this.concentration;
         this.concentration = next;
+        this.next = current;
 
         // Restore any temporary flow speed overrides after injection
         for (let i = 0; i < this.segments.length; i++) {


### PR DESCRIPTION
## Summary
- Preallocate a secondary concentration buffer when creating a `ContrastAgent`
- Clear and reuse preallocated buffers in `update` to reduce allocations
- Swap active and next buffers each frame to avoid cloning

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node -e "require('./contrastAgent.js')"`


------
https://chatgpt.com/codex/tasks/task_e_68af14a4e9e4832ea552a4d054d42101