### PR TITLE
Gracefully handle missing WebGL support

### DIFF
--- a/carmPreview.js
+++ b/carmPreview.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
 import { createCArmModel } from './carmModel.js';
 import { createOperatingTable } from './operatingTable.js';
 
@@ -11,6 +12,11 @@ let cArmGantry;
 export function initCArmPreview() {
     const container = document.getElementById('carm-preview');
     if (!container) return;
+
+    if (!WebGL.isWebGLAvailable()) {
+        container.textContent = 'WebGL not supported';
+        return;
+    }
 
     previewScene = new THREE.Scene();
 
@@ -29,9 +35,15 @@ export function initCArmPreview() {
     previewCamera.lookAt(0, 0, 0);
     previewScene.add(previewCamera);
 
-    previewRenderer = new THREE.WebGLRenderer({ antialias: true });
-    previewRenderer.setSize(width, height);
-    container.appendChild(previewRenderer.domElement);
+    try {
+        previewRenderer = new THREE.WebGLRenderer({ antialias: true });
+        previewRenderer.setSize(width, height);
+        container.appendChild(previewRenderer.domElement);
+    } catch (e) {
+        container.textContent = 'WebGL not supported';
+        console.warn('WebGL initialization failed:', e);
+        return;
+    }
 
     const table = createOperatingTable();
     // Lower the table so the patient lies below the C-arm's isocenter

--- a/simulator.js
+++ b/simulator.js
@@ -1,5 +1,13 @@
 import * as THREE from 'three';
-import { Guidewire, setBendingStiffness, setWallFriction, setNormalDamping, setVelocityDamping, setSmoothingParameters } from './physics/guidewire.js';
+import WebGL from 'three/examples/jsm/capabilities/WebGL.js';
+import {
+    Guidewire,
+    setBendingStiffness,
+    setWallFriction,
+    setNormalDamping,
+    setVelocityDamping,
+    setSmoothingParameters
+} from './physics/guidewire.js';
 import { generateVessel } from './vesselGeometry.js';
 import { setupCArmControls } from './carm.js';
 import { ContrastAgent, getContrastGeometry } from './contrastAgent.js';
@@ -8,8 +16,22 @@ import { initCArmPreview, cArmPreviewGroup, cArmPreviewGantry } from './carmPrev
 import { createBoneModel } from './boneModel.js';
 
 const canvas = document.getElementById('sim');
-const renderer = new THREE.WebGLRenderer({canvas, antialias: true});
-renderer.setSize(window.innerWidth, window.innerHeight);
+let renderer;
+if (WebGL.isWebGLAvailable()) {
+    try {
+        renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+        renderer.setSize(window.innerWidth, window.innerHeight);
+    } catch (e) {
+        const warning = WebGL.getWebGLErrorMessage();
+        document.body.appendChild(warning);
+        console.warn('WebGL initialization failed:', e);
+        throw e;
+    }
+} else {
+    const warning = WebGL.getWebGLErrorMessage();
+    document.body.appendChild(warning);
+    throw new Error('WebGL not supported');
+}
 
 const scene = new THREE.Scene();
 scene.background = new THREE.Color(0x000000);


### PR DESCRIPTION
## Summary
- Prevent crashes when WebGL context cannot be created by checking for availability before initializing Three.js renderer
- Display a warning and abort initialization if WebGL is unavailable, including in C-arm preview
- Catch WebGL renderer creation failures and fall back to warning message

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af16c56b64832e93221e478a173a4f