### PR TITLE
Add import map for WebGL capability module

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,7 +259,8 @@
     "imports": {
         "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
         "three-mesh-bvh": "https://cdn.jsdelivr.net/npm/three-mesh-bvh@0.7.5/build/index.module.js",
-        "three/examples/jsm/utils/BufferGeometryUtils.js": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/utils/BufferGeometryUtils.js"
+        "three/examples/jsm/utils/BufferGeometryUtils.js": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/utils/BufferGeometryUtils.js",
+        "three/examples/jsm/capabilities/WebGL.js": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/capabilities/WebGL.js"
     }
 }
 </script>


### PR DESCRIPTION
## Summary
- Map `three/examples/jsm/capabilities/WebGL.js` in import map to resolve module specifier at runtime

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af18e4f874832eac8f62c4895b3e69