### PR TITLE
Handle WebGL2-only contexts

### DIFF
--- a/carmPreview.js
+++ b/carmPreview.js
@@ -13,7 +13,7 @@ export function initCArmPreview() {
     const container = document.getElementById('carm-preview');
     if (!container) return;
 
-    if (!WebGL.isWebGLAvailable()) {
+    if (!(WebGL.isWebGLAvailable() || WebGL.isWebGL2Available())) {
         container.textContent = 'WebGL not supported';
         return;
     }

--- a/simulator.js
+++ b/simulator.js
@@ -17,7 +17,7 @@ import { createBoneModel } from './boneModel.js';
 
 const canvas = document.getElementById('sim');
 let renderer;
-if (WebGL.isWebGLAvailable()) {
+if (WebGL.isWebGLAvailable() || WebGL.isWebGL2Available()) {
     try {
         renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
         renderer.setSize(window.innerWidth, window.innerHeight);


### PR DESCRIPTION
## Summary
- consider WebGL2 availability when verifying renderer support
- ensure C-Arm preview and simulator initialize on devices exposing only WebGL2

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af1a806268832ebf80268c95cf588f