### PR TITLE
Add performance overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,17 @@
             border: 1px solid gray;
             background: black;
         }
+
+        #perfStats {
+            position: absolute;
+            bottom: 10px;
+            left: 10px;
+            color: white;
+            font-family: sans-serif;
+            background-color: rgba(0, 0, 0, 0.6);
+            padding: 4px;
+            border-radius: 4px;
+        }
     </style>
 </head>
 <body>
@@ -253,6 +264,7 @@
 </div>
 
 <div id="carm-preview"></div>
+<div id="perfStats">FPS: 0 | Mem: N/A</div>
 
 <script type="importmap">
 {

--- a/simulator.js
+++ b/simulator.js
@@ -255,6 +255,7 @@ const persistenceSlider = document.getElementById('persistence');
 const noiseSlider = document.getElementById('noiseLevel');
 const opacityScaleSlider = document.getElementById('opacityScale');
 const gainSlider = document.getElementById('gain');
+const perfStats = document.getElementById('perfStats');
 
 const sliders = [
     bendSlider,
@@ -567,6 +568,15 @@ function animate(time) {
     } else {
         renderer.setRenderTarget(null);
         renderer.render(scene, camera);
+    }
+
+    if (perfStats) {
+        const fps = (1 / dt).toFixed(1);
+        let mem = 'N/A';
+        if (performance.memory) {
+            mem = (performance.memory.usedJSHeapSize / 1048576).toFixed(1) + ' MB';
+        }
+        perfStats.textContent = `FPS: ${fps} | Mem: ${mem}`;
     }
 
     requestAnimationFrame(animate);


### PR DESCRIPTION
## Summary
- Display FPS and JavaScript heap usage in a new bottom-left overlay
- Update animation loop to refresh performance statistics each frame

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af67e8ca84832eb2770921bc3d0541