### PR TITLE
Increase contrast speed and reduce washout

### DIFF
--- a/contrastAgent.js
+++ b/contrastAgent.js
@@ -8,7 +8,8 @@ const geometryPool = new Map();
 
 // Simulates advection and dilution of a contrast agent through a vessel graph.
 export class ContrastAgent {
-    constructor(vessel, washout = 0.5, backflow = 0.2, debug = false, samplesPerSegment = 10) {
+    // Reduced default washout so contrast dilutes more slowly
+    constructor(vessel, washout = 0.25, backflow = 0.2, debug = false, samplesPerSegment = 10) {
         this.vessel = vessel;
         this.segments = vessel.segments;
         this.nodes = vessel.nodes || [];

--- a/contrastFlowDemo.js
+++ b/contrastFlowDemo.js
@@ -13,7 +13,8 @@ const vessel = {
       volume: Math.PI * 2 * 2 * 10,
       startNode: 0,
       endNode: 1,
-      flowSpeed: 5,
+      // Faster flow in proximal segment to reflect quicker contrast movement
+      flowSpeed: 10,
       parent: null,
     },
     // Distal segment
@@ -25,7 +26,8 @@ const vessel = {
       volume: Math.PI * 2 * 2 * 10,
       startNode: 1,
       endNode: 2,
-      flowSpeed: 5,
+      // Faster flow in distal segment as well
+      flowSpeed: 10,
       parent: 0,
     },
   ],

--- a/vesselGeometry.js
+++ b/vesselGeometry.js
@@ -216,7 +216,8 @@ export function generateVessel(branchLength = 140, branchAngleOffset = 0, sheath
     }
 
     // Compute flow direction and speed throughout the graph
-    const BASE_SPEED = 30; // cm/s default inflow speed
+    // Increased base speed so contrast advects faster through vessels
+    const BASE_SPEED = 60; // cm/s default inflow speed
     const flow = {};
     const computeDir = seg => {
         const dx = seg.end.x - seg.start.x;


### PR DESCRIPTION
## Summary
- Double vessel base flow speed for quicker contrast transport.
- Lower default washout so contrast lingers longer in simulation.
- Update demo vessel segments with faster flow values.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af6870ef3c832eb74d01b63d3faf93