### PR TITLE
Load skeleton OBJ model

### DIFF
--- a/boneModel.js
+++ b/boneModel.js
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader.js';
 
 export function createBoneModel() {
     // Use additive blending so bones brighten underlying geometry without occluding it
@@ -10,28 +11,24 @@ export function createBoneModel() {
         depthTest: false, // rely on render order so vessels draw on top
         blending: THREE.AdditiveBlending
     });
+
     const group = new THREE.Group();
+    const loader = new OBJLoader();
+    loader.load('skeleton.obj', (obj) => {
+        // Apply material to all meshes in the loaded model
+        obj.traverse(child => {
+            if (child.isMesh) {
+                child.material = material;
+            }
+        });
 
-    // Approximate pelvis using two hip boxes and a central sacrum
-    const hipGeom = new THREE.BoxGeometry(80, 100, 40);
-    const leftHip = new THREE.Mesh(hipGeom, material);
-    leftHip.position.set(-60, -50, 0);
-    leftHip.rotation.z = THREE.MathUtils.degToRad(20);
-    group.add(leftHip);
+        // Center the model so positioning behaves like the generated bones
+        const box = new THREE.Box3().setFromObject(obj);
+        const center = box.getCenter(new THREE.Vector3());
+        obj.position.sub(center);
 
-    const rightHip = new THREE.Mesh(hipGeom, material);
-    rightHip.position.set(60, -50, 0);
-    rightHip.rotation.z = THREE.MathUtils.degToRad(-20);
-    group.add(rightHip);
-
-    const sacrum = new THREE.Mesh(new THREE.CylinderGeometry(30, 40, 100, 16), material);
-    sacrum.position.set(0, -50, 0);
-    group.add(sacrum);
-
-    // Spine represented by a vertical cylinder emerging from the origin
-    const spine = new THREE.Mesh(new THREE.CylinderGeometry(20, 20, 400, 16), material);
-    spine.position.y = 200; // height 400 -> base at y=0
-    group.add(spine);
+        group.add(obj);
+    });
 
     return group;
 }


### PR DESCRIPTION
## Summary
- Load external `skeleton.obj` using `OBJLoader` instead of creating bones procedurally
- Center loaded skeleton and apply additive blending material for fluoroscopy visuals

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_68af6a0e41dc832eaa0c5d9d59f322c7