### PR TITLE
Rotate and scale skeleton model

### DIFF
--- a/boneModel.js
+++ b/boneModel.js
@@ -27,6 +27,10 @@ export function createBoneModel() {
         const center = box.getCenter(new THREE.Vector3());
         obj.position.sub(center);
 
+        // Rotate 45 degrees clockwise and scale up 10x
+        obj.rotation.y = -Math.PI / 4;
+        obj.scale.multiplyScalar(10);
+
         group.add(obj);
     });
 


### PR DESCRIPTION
## Summary
- rotate skeleton model 45° clockwise and enlarge 10x when loaded

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af6bf4a578832ea613c3315d043894