### PR TITLE
Accelerate contrast flow in vessels

### DIFF
--- a/contrastFlowDemo.js
+++ b/contrastFlowDemo.js
@@ -13,8 +13,8 @@ const vessel = {
       volume: Math.PI * 2 * 2 * 10,
       startNode: 0,
       endNode: 1,
-      // Faster flow in proximal segment to reflect quicker contrast movement
-      flowSpeed: 10,
+        // Faster flow in proximal segment to reflect quicker contrast movement
+        flowSpeed: 20,
       parent: null,
     },
     // Distal segment
@@ -26,8 +26,8 @@ const vessel = {
       volume: Math.PI * 2 * 2 * 10,
       startNode: 1,
       endNode: 2,
-      // Faster flow in distal segment as well
-      flowSpeed: 10,
+        // Faster flow in distal segment as well
+        flowSpeed: 20,
       parent: 0,
     },
   ],

--- a/vesselGeometry.js
+++ b/vesselGeometry.js
@@ -217,7 +217,7 @@ export function generateVessel(branchLength = 140, branchAngleOffset = 0, sheath
 
     // Compute flow direction and speed throughout the graph
     // Increased base speed so contrast advects faster through vessels
-    const BASE_SPEED = 60; // cm/s default inflow speed
+    const BASE_SPEED = 90; // cm/s default inflow speed
     const flow = {};
     const computeDir = seg => {
         const dx = seg.end.x - seg.start.x;


### PR DESCRIPTION
## Summary
- Increase base inflow speed to 90 cm/s so contrast propagates faster through vessels
- Speed up flow in demo segments to better illustrate accelerated contrast movement

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af70597a3c832eab677a0443b9277b