### PR TITLE
Reduce default wall friction for wire straightening

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ The vessel is generated deterministically. Branch length and angle offset use fi
 
 ## Tuning wall friction
 
-The guidewire uses a simple Coulomb model when it collides with the vessel wall. Static and kinetic friction coefficients and the amount of normal damping can be adjusted at runtime to control how easily the wire slides and straightens after withdrawal.
+The guidewire uses a simple Coulomb model when it collides with the vessel wall. Static and kinetic friction coefficients and the amount of normal damping can be adjusted at runtime to control how easily the wire slides and straightens after withdrawal. Lower defaults are already applied to minimise sticking, but you can tweak them further:
 
 ```js
 import { setWallFriction, setNormalDamping } from './physics/guidewire.js';
 
 // lower values reduce sticking on the vessel wall
-setWallFriction(0.1, 0.05);
-setNormalDamping(0.3);
+setWallFriction(0.05, 0.02);
+setNormalDamping(0.2);
 ```
 
 Providing smaller coefficients allows the wire to shed kinks more readily when pulled back through a branch.

--- a/physics/guidewire.js
+++ b/physics/guidewire.js
@@ -1,9 +1,11 @@
 // Wall interaction parameters with defaults
 // Friction values are coefficients relative to the normal component of
 // velocity. Normal damping acts like a restitution coefficient.
-let wallStaticFriction = 0.2;
-let wallKineticFriction = 0.1;
-let wallNormalDamping = 0.5;
+// Lower defaults reduce the tendency for the wire to "stick" to the vessel wall
+// and allow it to straighten more readily when there is space.
+let wallStaticFriction = 0.1;
+let wallKineticFriction = 0.05;
+let wallNormalDamping = 0.3;
 
 // Force applied to the tip when advancing the tail
 let advanceForce = 100;


### PR DESCRIPTION
## Summary
- lower default static and kinetic wall friction plus normal damping to prevent wire sticking and encourage straightening when space allows
- document tunable wall friction and updated defaults in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b05cdfa1dc832e861dadc692c15ee6