### PR TITLE
Relax curvature near vessel radius

### DIFF
--- a/physics/guidewire.js
+++ b/physics/guidewire.js
@@ -456,7 +456,8 @@ export class Guidewire {
                     }
                 }
                 const radius = nearest.radius - 1;
-                if (best.dist < radius) {
+                const epsilon = 0.01;
+                if (best.dist <= radius + epsilon) {
                     const prev = this.nodes[i - 1];
                     const next = this.nodes[i + 1];
                     const projNeighbor = projectOnSegment(n, {start: prev, end: next});
@@ -465,6 +466,7 @@ export class Guidewire {
                     n.x += (target.px - n.x) * strength;
                     n.y += (target.py - n.y) * strength;
                     n.z += (target.pz - n.z) * strength;
+                    clampToVessel(n, this.vessel, false, undefined, undefined, undefined, this.openEnds);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Include nodes on vessel boundary in curvature relaxation with small epsilon
- Reclamp adjusted nodes to vessel without affecting velocity

## Testing
- `node --input-type=module` script demonstrates interior relaxation of a node previously ignored
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b06ace79b8832ea416ae9e05cf901a