### PR TITLE
Add curvature forces and smoothing to ElasticRod

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,10 @@ the midpoint of their neighbours. Positions are integrated with a semi-implicit
 Euler step followed by constraint projection and a small velocity damping
 factor. This simple model ignores shear and torsion and is stable for time
 steps of roughly `0.01` seconds or smaller.
+
+Curvature for each node is computed from neighbouring positions and a
+straightening force proportional to the node's `bendingStiffness` is applied.
+After constraints are solved an optional Laplacian smoothing pass can further
+relax sharp bends. Default values for bending stiffness and the number of
+smoothing iterations may be configured via the `setBendingStiffness` and
+`setSmoothingIterations` functions exported from `physics/elasticRod.js`.

--- a/physics/elasticRod.test.js
+++ b/physics/elasticRod.test.js
@@ -21,3 +21,14 @@ for (let i = 0; i < rod.nodes.length - 1; i++) {
 }
 
 console.log('max length deviation', maxErr.toFixed(4));
+
+// check that curvature is computed and tends toward zero after simulation
+rod.updateCurvature();
+const k = Math.hypot(rod.nodes[2].kx, rod.nodes[2].ky, rod.nodes[2].kz);
+console.log('center curvature magnitude', k.toFixed(4));
+
+// verify optional Laplacian smoothing moves nodes toward neighbor average
+const smoothRod = new ElasticRod(5, 1, { mass: 1, bendingStiffness: 0, smoothingIterations: 5 });
+smoothRod.nodes[2].y = 1;
+smoothRod.step(dt);
+console.log('smoothed center y', smoothRod.nodes[2].y.toFixed(4));


### PR DESCRIPTION
## Summary
- compute curvature vector per node and apply straightening force scaled by bending stiffness
- support configurable default bending stiffness and Laplacian smoothing iterations via setters
- add optional Laplacian smoothing after constraint resolution
- update tests for curvature calculation and smoothing

## Testing
- `node physics/elasticRod.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0d9e01894832ea70a0858036c9e08