### PR TITLE
Add elastic rod tests, logging and visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,32 @@ After constraints are solved an optional Laplacian smoothing pass can further
 relax sharp bends. Default values for bending stiffness and the number of
 smoothing iterations may be configured via the `setBendingStiffness` and
 `setSmoothingIterations` functions exported from `physics/elasticRod.js`.
+
+## Simulation logging and tests
+
+`ElasticRod` accepts an optional `logger` callback. When provided, the callback
+is invoked after each `step` with the current iteration count, average
+curvature and total rod length:
+
+```js
+const rod = new ElasticRod(10, 1, {
+  logger: data => console.log(data)
+});
+```
+
+Example scripts exercising the rod model live in `tests/elasticRod`:
+
+* `straightening.js` – rod straightening after release
+* `wallBend.js` – bending while sliding along a vessel wall
+* `branchCollision.js` – collision at a vessel bifurcation
+
+Run them with Node to produce JSON logs describing the simulation state:
+
+```sh
+node tests/elasticRod/straightening.js
+node tests/elasticRod/wallBend.js
+node tests/elasticRod/branchCollision.js
+```
+
+For a quick visual check, open `tests/elasticRod/visualize.html` in a modern
+browser. It uses Three.js to display the rod evolving in isolation.

--- a/tests/elasticRod/branchCollision.js
+++ b/tests/elasticRod/branchCollision.js
@@ -1,0 +1,33 @@
+import { ElasticRod } from '../../physics/elasticRod.js';
+import fs from 'fs';
+
+const log = [];
+const rod = new ElasticRod(20, 0.3, {
+    logger: entry => log.push(entry)
+});
+
+// vessel with a side branch
+const vessel = {
+    segments: [
+        { start: { x: 0, y: 0, z: 0 }, end: { x: 3, y: 0, z: 0 }, radius: 1 },
+        { start: { x: 3, y: 0, z: 0 }, end: { x: 6, y: 0, z: 0 }, radius: 1 },
+        { start: { x: 3, y: 0, z: 0 }, end: { x: 3, y: 3, z: 0 }, radius: 1 }
+    ]
+};
+
+const dt = 0.01;
+for (let i = 0; i < 400; i++) {
+    // push tip forward
+    rod.nodes[rod.nodes.length - 1].vx = 1;
+    // bias upward to prefer the branch
+    if (rod.nodes[rod.nodes.length - 1].x > 2.5) {
+        rod.nodes[rod.nodes.length - 1].vy = 1;
+    }
+    rod.step(dt);
+    rod.collide(vessel, dt);
+}
+
+const logPath = new URL('./branch-collision.log', import.meta.url);
+fs.writeFileSync(logPath, JSON.stringify(log, null, 2));
+console.log('saved log to', logPath.pathname);
+console.log('final tip', rod.nodes[rod.nodes.length - 1]);

--- a/tests/elasticRod/straightening.js
+++ b/tests/elasticRod/straightening.js
@@ -1,0 +1,20 @@
+import { ElasticRod } from '../../physics/elasticRod.js';
+import fs from 'fs';
+
+const log = [];
+const rod = new ElasticRod(10, 1, {
+    logger: entry => log.push(entry)
+});
+
+// bend the rod at the center
+rod.nodes[5].y = 2;
+
+const dt = 0.01;
+for (let i = 0; i < 200; i++) {
+    rod.step(dt);
+}
+
+const logPath = new URL('./straightening.log', import.meta.url);
+fs.writeFileSync(logPath, JSON.stringify(log, null, 2));
+console.log('saved log to', logPath.pathname);
+console.log('final curvature', log[log.length - 1].curvature.toFixed(4));

--- a/tests/elasticRod/visualize.html
+++ b/tests/elasticRod/visualize.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Elastic Rod Visualizer</title>
+<style>body{margin:0;overflow:hidden}</style>
+</head>
+<body>
+<canvas id="c"></canvas>
+<script type="module" src="./visualize.js"></script>
+</body>
+</html>

--- a/tests/elasticRod/visualize.js
+++ b/tests/elasticRod/visualize.js
@@ -1,0 +1,36 @@
+import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+import { ElasticRod } from '../../physics/elasticRod.js';
+
+const rod = new ElasticRod(20, 0.5);
+rod.nodes[5].y = 1;
+
+const renderer = new THREE.WebGLRenderer({ canvas: document.getElementById('c') });
+renderer.setSize(window.innerWidth, window.innerHeight);
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 100);
+camera.position.set(5,5,5);
+camera.lookAt(0,0,0);
+
+const material = new THREE.LineBasicMaterial({ color: 0xff0000 });
+const geometry = new THREE.BufferGeometry();
+const line = new THREE.Line(geometry, material);
+scene.add(line);
+
+function updateGeometry() {
+    const positions = [];
+    for (const n of rod.nodes) {
+        positions.push(n.x, n.y, n.z);
+    }
+    geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    geometry.attributes.position.needsUpdate = true;
+}
+
+function animate() {
+    rod.step(0.01);
+    updateGeometry();
+    renderer.render(scene, camera);
+    requestAnimationFrame(animate);
+}
+
+updateGeometry();
+animate();

--- a/tests/elasticRod/wallBend.js
+++ b/tests/elasticRod/wallBend.js
@@ -1,0 +1,30 @@
+import { ElasticRod } from '../../physics/elasticRod.js';
+import fs from 'fs';
+
+const log = [];
+const rod = new ElasticRod(10, 0.5, {
+    logger: entry => log.push(entry)
+});
+
+// simple vessel: straight tube along x
+const vessel = {
+    segments: [
+        { start: { x: 0, y: 0, z: 0 }, end: { x: 5, y: 0, z: 0 }, radius: 1 }
+    ]
+};
+
+// place tip slightly outside to force contact with wall
+rod.nodes[rod.nodes.length - 1].y = 1.2;
+
+const dt = 0.01;
+for (let i = 0; i < 200; i++) {
+    // push tip along the vessel
+    rod.nodes[rod.nodes.length - 1].vx = 1;
+    rod.step(dt);
+    rod.collide(vessel, dt);
+}
+
+const logPath = new URL('./wall-bend.log', import.meta.url);
+fs.writeFileSync(logPath, JSON.stringify(log, null, 2));
+console.log('saved log to', logPath.pathname);
+console.log('final tip', rod.nodes[rod.nodes.length - 1]);


### PR DESCRIPTION
## Summary
- extend ElasticRod with optional logger to record iteration, curvature and length
- add three elastic rod test scenarios with JSON logging and a Three.js visualizer
- document logging option and test usage in README

## Testing
- `node tests/elasticRod/straightening.js`
- `node tests/elasticRod/wallBend.js`
- `node tests/elasticRod/branchCollision.js`
- `node physics/elasticRod.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b1b085d538832e8eea3adb27ac71f5