### PR TITLE
Move C-arm controls under preview and add joystick XY control

### DIFF
--- a/carm.js
+++ b/carm.js
@@ -97,5 +97,48 @@ export function setupCArmControls(camera, vessel, cameraRadius, previewGroup, pr
         carmZ = parseFloat(e.target.value);
         updateCamera();
     });
+    const joystick = document.getElementById('joystick');
+    const joystickHandle = document.getElementById('joystick-handle');
+    if (joystick && joystickHandle) {
+        const handleRadius = joystickHandle.offsetWidth / 2;
+        const maxDistance = joystick.offsetWidth / 2 - handleRadius;
+        let dragging = false;
+
+        function updateFromJoystick(clientX, clientY) {
+            const rect = joystick.getBoundingClientRect();
+            let x = clientX - rect.left - rect.width / 2;
+            let y = clientY - rect.top - rect.height / 2;
+            const dist = Math.hypot(x, y);
+            if (dist > maxDistance) {
+                const ratio = maxDistance / dist;
+                x *= ratio;
+                y *= ratio;
+            }
+            joystickHandle.style.transform = `translate(-50%, -50%) translate(${x}px, ${y}px)`;
+            const normX = x / maxDistance;
+            const normY = y / maxDistance;
+            const minX = parseFloat(carmXSlider.min);
+            const maxX = parseFloat(carmXSlider.max);
+            const minY = parseFloat(carmYSlider.min);
+            const maxY = parseFloat(carmYSlider.max);
+            carmX = minX + (normX + 1) / 2 * (maxX - minX);
+            carmY = minY + (1 - (normY + 1) / 2) * (maxY - minY);
+            carmXSlider.value = carmX;
+            carmYSlider.value = carmY;
+            updateCamera();
+        }
+
+        joystick.addEventListener('mousedown', e => {
+            dragging = true;
+            updateFromJoystick(e.clientX, e.clientY);
+        });
+        window.addEventListener('mousemove', e => {
+            if (!dragging) return;
+            updateFromJoystick(e.clientX, e.clientY);
+        });
+        window.addEventListener('mouseup', () => {
+            dragging = false;
+        });
+    }
 }
 

--- a/index.html
+++ b/index.html
@@ -18,19 +18,48 @@
             position: absolute;
             top: 10px;
             left: 10px;
+            width: 200px;
+            max-height: calc(100vh - 20px);
+            overflow-y: auto;
+        }
+        #carm-controls {
+            position: absolute;
+            top: 430px;
+            right: 10px;
+            width: 300px;
+        }
+        #controls, #carm-controls {
             color: white;
             font-family: sans-serif;
             font-size: 14px;
             background-color: rgba(0, 0, 0, 0.6);
             padding: 8px;
             border-radius: 4px;
-            width: 200px;
-            max-height: calc(100vh - 20px);
-            overflow-y: auto;
         }
-        #controls label {
+        #controls label, #carm-controls label {
             display: block;
             margin-bottom: 4px;
+        }
+
+        #joystick {
+            position: relative;
+            width: 120px;
+            height: 120px;
+            margin: 10px auto;
+            background-color: rgba(255, 255, 255, 0.1);
+            border: 1px solid #666;
+            border-radius: 50%;
+            touch-action: none;
+        }
+        #joystick-handle {
+            position: absolute;
+            width: 30px;
+            height: 30px;
+            background-color: rgba(255, 255, 255, 0.8);
+            border-radius: 50%;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
         }
 
         .parameter-label {
@@ -217,9 +246,30 @@
         </div>
     </div>
 
+    <button id="injectContrast">Inject</button>
+    <button id="stopInjection" disabled>Stop Injection</button>
+    <button id="modeToggle">Wireframe</button>
+</div>
+
+<div id="monitor">
+    <div class="vitalBox" id="hrBox">
+        <canvas id="ecgCanvas" width="300" height="100"></canvas>
+        <div class="vitalLabel">HR: <span id="hrValue">0</span></div>
+    </div>
+    <div class="vitalBox" id="bpBox">
+        <canvas id="bpCanvas" width="300" height="100"></canvas>
+        <div class="vitalLabel">BP: <span id="bpValue">0/0</span></div>
+    </div>
+</div>
+
+<div id="carm-preview"></div>
+<div id="carm-controls">
     <div class="control-section">
         <div class="section-header"><span class="collapse-triangle">▼</span> C-arm</div>
         <div class="section-content">
+            <div id="joystick">
+                <div id="joystick-handle"></div>
+            </div>
             <label class="parameter-label">C-arm yaw
                 <input id="carmYaw" type="range" min="-180" max="180" step="1" value="0">
                 <span></span>
@@ -246,24 +296,7 @@
             </label>
         </div>
     </div>
-
-    <button id="injectContrast">Inject</button>
-    <button id="stopInjection" disabled>Stop Injection</button>
-    <button id="modeToggle">Wireframe</button>
 </div>
-
-<div id="monitor">
-    <div class="vitalBox" id="hrBox">
-        <canvas id="ecgCanvas" width="300" height="100"></canvas>
-        <div class="vitalLabel">HR: <span id="hrValue">0</span></div>
-    </div>
-    <div class="vitalBox" id="bpBox">
-        <canvas id="bpCanvas" width="300" height="100"></canvas>
-        <div class="vitalLabel">BP: <span id="bpValue">0/0</span></div>
-    </div>
-</div>
-
-<div id="carm-preview"></div>
 <div id="perfStats">FPS: 0 | Mem: N/A</div>
 
 <script type="importmap">

--- a/simulator.js
+++ b/simulator.js
@@ -279,7 +279,7 @@ const sliders = [
 sliders.forEach(s => s.addEventListener('change', () => s.blur()));
 
 // Display current values next to each slider
-document.querySelectorAll('#controls input[type="range"]').forEach(slider => {
+document.querySelectorAll('#controls input[type="range"], #carm-controls input[type="range"]').forEach(slider => {
     const valueLabel = slider.nextElementSibling;
     if (!valueLabel) return;
     const update = () => { valueLabel.textContent = slider.value; };


### PR DESCRIPTION
## Summary
- Move C-arm control sliders to a dedicated panel beneath the C-arm preview
- Add a draggable on-screen joystick to steer the C-arm in the XY plane
- Update UI scripts to hook joystick motion to the existing X/Y sliders

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b2bb23188c832eb4d1a0e77550beed