### PR TITLE
Add thickness-based fluoroscopy shader

### DIFF
--- a/boneModel.js
+++ b/boneModel.js
@@ -2,32 +2,47 @@ import * as THREE from 'three';
 import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader.js';
 
 export function createBoneModel() {
-    // Use additive blending so bones brighten underlying geometry without occluding it
-    const material = new THREE.MeshStandardMaterial({
-        color: 0xffffff,
+    const material = new THREE.ShaderMaterial({
+        uniforms: {
+            thicknessMap: { value: null },
+            muBone: { value: 4.0 },
+            resolution: { value: new THREE.Vector2(1, 1) }
+        },
         transparent: true,
-        opacity: 0.5, // reduce brightness so bones are less dominant
         depthWrite: false,
-        depthTest: false, // rely on render order so vessels draw on top
-        blending: THREE.AdditiveBlending
+        depthTest: false,
+        blending: THREE.NoBlending,
+        vertexShader: `
+            void main() {
+                gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+            }
+        `,
+        fragmentShader: `
+            uniform sampler2D thicknessMap;
+            uniform float muBone;
+            uniform vec2 resolution;
+            void main() {
+                vec2 uv = gl_FragCoord.xy / resolution;
+                float d = texture2D(thicknessMap, uv).r;
+                float absorb = 1.0 - exp(-muBone * d);
+                gl_FragColor = vec4(vec3(absorb), 1.0);
+            }
+        `
     });
 
     const group = new THREE.Group();
     const loader = new OBJLoader();
     loader.load('skeleton.obj', (obj) => {
-        // Apply material to all meshes in the loaded model
         obj.traverse(child => {
             if (child.isMesh) {
                 child.material = material;
             }
         });
 
-        // Center the model so positioning behaves like the generated bones
         const box = new THREE.Box3().setFromObject(obj);
         const center = box.getCenter(new THREE.Vector3());
         obj.position.sub(center);
 
-        // Rotate 45 degrees clockwise and scale up 10x
         obj.rotation.z = -Math.PI / 3;
         obj.scale.multiplyScalar(9);
         obj.position.x -= 1760;
@@ -37,6 +52,6 @@ export function createBoneModel() {
         group.add(obj);
     });
 
-    return group;
+    return { group, material };
 }
 

--- a/simulator.js
+++ b/simulator.js
@@ -30,6 +30,9 @@ const offscreenTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.in
 const contrastTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
 const accumulateTarget1 = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
 const accumulateTarget2 = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
+const frontDepthTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
+const backDepthTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
+const thicknessTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
 let previousTarget = accumulateTarget1;
 let currentTarget = accumulateTarget2;
 
@@ -63,6 +66,36 @@ const blendMaterial = new THREE.ShaderMaterial({
 const blendQuad = new THREE.Mesh(quadGeometry, blendMaterial);
 const blendScene = new THREE.Scene();
 blendScene.add(blendQuad);
+
+const depthMaterialFront = new THREE.MeshDepthMaterial({ side: THREE.FrontSide });
+const depthMaterialBack = new THREE.MeshDepthMaterial({ side: THREE.BackSide });
+const thicknessMaterial = new THREE.ShaderMaterial({
+    uniforms: {
+        frontDepth: { value: frontDepthTarget.texture },
+        backDepth: { value: backDepthTarget.texture }
+    },
+    vertexShader: `
+        varying vec2 vUv;
+        void main() {
+            vUv = uv;
+            gl_Position = vec4(position.xy, 0.0, 1.0);
+        }
+    `,
+    fragmentShader: `
+        uniform sampler2D frontDepth;
+        uniform sampler2D backDepth;
+        varying vec2 vUv;
+        void main() {
+            float front = texture2D(frontDepth, vUv).r;
+            float back = texture2D(backDepth, vUv).r;
+            float thick = max(back - front, 0.0);
+            gl_FragColor = vec4(vec3(thick), 1.0);
+        }
+    `
+});
+const thicknessQuad = new THREE.Mesh(quadGeometry, thicknessMaterial);
+const thicknessScene = new THREE.Scene();
+thicknessScene.add(thicknessQuad);
 
 const displayMaterial = new THREE.ShaderMaterial({
     uniforms: {
@@ -127,7 +160,8 @@ scene.add(light);
 
 let vesselMaterial = new THREE.MeshStandardMaterial({color: 0x3366ff});
 let vesselGroup;
-const boneGroup = createBoneModel();
+const { group: boneGroup, material: boneMaterial } = createBoneModel();
+boneMaterial.uniforms.resolution.value.set(window.innerWidth, window.innerHeight);
 
 const { geometry, vessel } = generateVessel(140, 0); // deterministic branch parameters
 vesselGroup = new THREE.Group();
@@ -528,6 +562,31 @@ function animate(time) {
     stopInjectButton.disabled = !injecting;
     monitor.update(dt);
     if (fluoroscopy) {
+        const hidden = [];
+        for (const child of scene.children) {
+            if (child !== boneGroup && !child.isCamera) {
+                hidden.push({ obj: child, visible: child.visible });
+                child.visible = false;
+            }
+        }
+        scene.overrideMaterial = depthMaterialFront;
+        renderer.setRenderTarget(frontDepthTarget);
+        renderer.clear();
+        renderer.render(scene, camera);
+        scene.overrideMaterial = depthMaterialBack;
+        renderer.setRenderTarget(backDepthTarget);
+        renderer.clear();
+        renderer.render(scene, camera);
+        scene.overrideMaterial = null;
+        renderer.setRenderTarget(null);
+        for (const h of hidden) h.obj.visible = h.visible;
+        thicknessMaterial.uniforms.frontDepth.value = frontDepthTarget.texture;
+        thicknessMaterial.uniforms.backDepth.value = backDepthTarget.texture;
+        renderer.setRenderTarget(thicknessTarget);
+        renderer.render(thicknessScene, postCamera);
+        renderer.setRenderTarget(null);
+        boneMaterial.uniforms.thicknessMap.value = thicknessTarget.texture;
+
         renderer.setRenderTarget(contrastTarget);
         withTransparentClear(renderer, () => {
             renderer.clear();
@@ -581,5 +640,9 @@ window.addEventListener('resize', () => {
     contrastTarget.setSize(w, h);
     accumulateTarget1.setSize(w, h);
     accumulateTarget2.setSize(w, h);
+    frontDepthTarget.setSize(w, h);
+    backDepthTarget.setSize(w, h);
+    thicknessTarget.setSize(w, h);
+    boneMaterial.uniforms.resolution.value.set(w, h);
 });
 


### PR DESCRIPTION
## Summary
- Replace bone mesh material with Beer–Lambert shader that darkens bones based on X-ray thickness
- Render front/back depth passes and compute thickness map for skeletal absorption
- Update rendering loop and resize handling to generate and use thickness textures

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_68b2b89ef448832eac14a6056a0ee28f