### PR TITLE
feat: improve bone model blending

### DIFF
--- a/boneModel.js
+++ b/boneModel.js
@@ -11,7 +11,7 @@ export function createBoneModel() {
         transparent: true,
         depthWrite: false,
         depthTest: false,
-        blending: THREE.NoBlending,
+        blending: THREE.AdditiveBlending,
         vertexShader: `
             void main() {
                 gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
@@ -25,7 +25,7 @@ export function createBoneModel() {
                 vec2 uv = gl_FragCoord.xy / resolution;
                 float d = texture2D(thicknessMap, uv).r;
                 float absorb = 1.0 - exp(-muBone * d);
-                gl_FragColor = vec4(vec3(absorb), 1.0);
+                gl_FragColor = vec4(vec3(absorb), absorb);
             }
         `
     });


### PR DESCRIPTION
## Summary
- use additive blending for bone shader to integrate absorption with scene
- encode x-ray absorption in alpha channel to support blending

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node simulator.js` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f5467908832ead3d64a0f1cbce7c