### PR TITLE
Handle far surfaces in back depth material

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -68,7 +68,10 @@ const blendScene = new THREE.Scene();
 blendScene.add(blendQuad);
 
 const depthMaterialFront = new THREE.MeshDepthMaterial({ side: THREE.FrontSide });
-const depthMaterialBack = new THREE.MeshDepthMaterial({ side: THREE.BackSide });
+const depthMaterialBack = new THREE.MeshDepthMaterial({
+    side: THREE.BackSide,
+    depthFunc: THREE.GreaterEqualDepth // capture far surfaces
+});
 const thicknessMaterial = new THREE.ShaderMaterial({
     uniforms: {
         frontDepth: { value: frontDepthTarget.texture },


### PR DESCRIPTION
## Summary
- Capture far surfaces in the back-side depth pass by using `THREE.GreaterEqualDepth`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node simulator.js` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f543e954832eafe4f73cd13e9f4b