### PR TITLE
Correct back-face depth pass and bone blending

### DIFF
--- a/boneModel.js
+++ b/boneModel.js
@@ -2,32 +2,47 @@ import * as THREE from 'three';
 import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader.js';
 
 export function createBoneModel() {
-    // Use additive blending so bones brighten underlying geometry without occluding it
-    const material = new THREE.MeshStandardMaterial({
-        color: 0xffffff,
+    const material = new THREE.ShaderMaterial({
+        uniforms: {
+            thicknessMap: { value: null },
+            muBone: { value: 4.0 },
+            resolution: { value: new THREE.Vector2(1, 1) }
+        },
         transparent: true,
-        opacity: 0.5, // reduce brightness so bones are less dominant
         depthWrite: false,
-        depthTest: false, // rely on render order so vessels draw on top
-        blending: THREE.AdditiveBlending
+        depthTest: false,
+        blending: THREE.AdditiveBlending,
+        vertexShader: `
+            void main() {
+                gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+            }
+        `,
+        fragmentShader: `
+            uniform sampler2D thicknessMap;
+            uniform float muBone;
+            uniform vec2 resolution;
+            void main() {
+                vec2 uv = gl_FragCoord.xy / resolution;
+                float d = texture2D(thicknessMap, uv).r;
+                float absorb = 1.0 - exp(-muBone * d);
+                gl_FragColor = vec4(vec3(absorb), absorb);
+            }
+        `
     });
 
     const group = new THREE.Group();
     const loader = new OBJLoader();
     loader.load('skeleton.obj', (obj) => {
-        // Apply material to all meshes in the loaded model
         obj.traverse(child => {
             if (child.isMesh) {
                 child.material = material;
             }
         });
 
-        // Center the model so positioning behaves like the generated bones
         const box = new THREE.Box3().setFromObject(obj);
         const center = box.getCenter(new THREE.Vector3());
         obj.position.sub(center);
 
-        // Rotate 45 degrees clockwise and scale up 10x
         obj.rotation.z = -Math.PI / 3;
         obj.scale.multiplyScalar(9);
         obj.position.x -= 1760;
@@ -37,6 +52,6 @@ export function createBoneModel() {
         group.add(obj);
     });
 
-    return group;
+    return { group, material };
 }
 


### PR DESCRIPTION
## Summary
- Render back-facing depth with a reversed depth test to produce a non-zero bone thickness map
- Blend bone absorption additively and use alpha equal to absorption so guidewire remains visible

## Testing
- `npm test` *(fails: no test specified)*
- `node --check boneModel.js`
- `node --check simulator.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2b89ef448832eac14a6056a0ee28f