### PR TITLE
Limit initial guidewire insertion

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -188,7 +188,8 @@ if (injSegmentSelect) {
 const segmentLength = 12;
 const nodeCount = 80;
 const initialWireLength = segmentLength * (nodeCount - 1);
-const initialInsert = segmentLength * 10;
+// Only insert a small portion of the wire so most remains outside the vessel
+const initialInsert = segmentLength * 2;
 
 const leftDir = {
     x: (vessel.branchPoint.x - vessel.left.end.x) / vessel.left.length,


### PR DESCRIPTION
## Summary
- Keep most of the guidewire outside the vessel by inserting only two segments at startup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fd13b7b8832e8a3b6b65c29c8523