### PR TITLE
Add joystick control for C-arm translation

### DIFF
--- a/carm.js
+++ b/carm.js
@@ -97,5 +97,55 @@ export function setupCArmControls(camera, vessel, cameraRadius, previewGroup, pr
         carmZ = parseFloat(e.target.value);
         updateCamera();
     });
+
+    // Joystick control for C-arm translation speed
+    const joystick = document.getElementById('joystick');
+    const joystickContainer = document.getElementById('joystick-container');
+    let joyX = 0;
+    let joyY = 0;
+    let joystickActive = false;
+
+    function handleJoystickMove(e) {
+        const rect = joystickContainer.getBoundingClientRect();
+        const x = e.clientX - rect.left - rect.width / 2;
+        const y = e.clientY - rect.top - rect.height / 2;
+        const max = rect.width / 2;
+        joyX = Math.max(-1, Math.min(1, x / max));
+        joyY = Math.max(-1, Math.min(1, y / max));
+        joystick.style.transform = `translate(${joyX * max}px, ${joyY * max}px)`;
+    }
+
+    function resetJoystick() {
+        joystickActive = false;
+        joyX = 0;
+        joyY = 0;
+        joystick.style.transform = '';
+    }
+
+    if (joystick && joystickContainer) {
+        joystickContainer.addEventListener('pointerdown', e => {
+            joystickActive = true;
+            handleJoystickMove(e);
+            requestAnimationFrame(applyJoystick);
+        });
+        window.addEventListener('pointermove', e => {
+            if (joystickActive) handleJoystickMove(e);
+        });
+        window.addEventListener('pointerup', resetJoystick);
+        window.addEventListener('pointerleave', resetJoystick);
+    }
+
+    const speedScale = 0.5;
+    function applyJoystick() {
+        if (!joystickActive) return;
+        carmX += joyX * speedScale;
+        carmY -= joyY * speedScale;
+        carmX = Math.max(parseFloat(carmXSlider.min), Math.min(parseFloat(carmXSlider.max), carmX));
+        carmY = Math.max(parseFloat(carmYSlider.min), Math.min(parseFloat(carmYSlider.max), carmY));
+        carmXSlider.value = carmX;
+        carmYSlider.value = carmY;
+        updateCamera();
+        requestAnimationFrame(applyJoystick);
+    }
 }
 

--- a/index.html
+++ b/index.html
@@ -126,6 +126,28 @@
             padding: 4px;
             border-radius: 4px;
         }
+        #joystick-container {
+            position: absolute;
+            bottom: 100px;
+            left: 20px;
+            width: 120px;
+            height: 120px;
+            border: 2px solid #666;
+            border-radius: 50%;
+            background: rgba(255, 255, 255, 0.1);
+            touch-action: none;
+        }
+        #joystick {
+            position: absolute;
+            width: 40px;
+            height: 40px;
+            left: 40px;
+            top: 40px;
+            background: rgba(200, 200, 200, 0.5);
+            border-radius: 50%;
+            pointer-events: none;
+            transition: transform 0.1s ease-out;
+        }
     </style>
 </head>
 <body>
@@ -265,6 +287,7 @@
 
 <div id="carm-preview"></div>
 <div id="perfStats">FPS: 0 | Mem: N/A</div>
+<div id="joystick-container"><div id="joystick"></div></div>
 
 <script type="importmap">
 {


### PR DESCRIPTION
## Summary
- Enable joystick to drive C-arm translation only while pressed and reset to center on release
- Add smooth centering transition for on-screen joystick knob

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fdd52a5c832ebc44caafc00d48ee