### PR TITLE
Improve skeleton visibility in fluoroscopy

### DIFF
--- a/boneModel.js
+++ b/boneModel.js
@@ -3,13 +3,14 @@ import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader.js';
 
 export function createBoneModel() {
     // Use additive blending so bones brighten underlying geometry without occluding it
-    const material = new THREE.MeshStandardMaterial({
+    const material = new THREE.MeshBasicMaterial({
         color: 0xffffff,
         transparent: true,
         opacity: 0.5, // reduce brightness so bones are less dominant
         depthWrite: false,
         depthTest: false, // rely on render order so vessels draw on top
-        blending: THREE.AdditiveBlending
+        blending: THREE.AdditiveBlending,
+        side: THREE.DoubleSide
     });
 
     const group = new THREE.Group();

--- a/simulator.js
+++ b/simulator.js
@@ -99,13 +99,13 @@ const displayMaterial = new THREE.ShaderMaterial({
         void main() {
             vec4 tex = texture2D(uTexture, vUv);
             if (fluoroscopy) {
-                float intensity = tex.r * boneOpacity;
+                float intensity = max(tex.r, max(tex.g, tex.b)) * boneOpacity;
                 float noise = random(vUv * 100.0) - 0.5;
                 intensity += noise * noiseLevel;
                 intensity = clamp(intensity, 0.0, 1.0);
                 vec4 cSample = texture2D(contrastTexture, vUv);
                 float contrast = clamp((cSample.r + cSample.b) * 2.0, 0.0, 1.0);
-                vec3 color = gray * (1.0 - intensity);
+                vec3 color = mix(gray, vec3(1.0), intensity);
                 gl_FragColor = vec4(mix(color, vec3(0.0), contrast), 1.0);
             } else {
                 gl_FragColor = tex;


### PR DESCRIPTION
## Summary
- switch skeleton to basic material so lighting does not hide it
- brighten and normalize skeleton intensity in fluoroscopy shader

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ffb8e284832eb4abb15e7902ff86