### PR TITLE
Route guidewire through sheath before vessel entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This prototype demonstrates a basic browser-based simulator for guiding a stiff 
 
 ## Usage
 
-Open `index.html` in a modern browser. Use `W`/`S` or the up/down arrow keys to advance or retract the guidewire through the introducer sheath positioned in the left branch. The sheath exits this branch with a fixed 30° anterior (+Z) angulation, and the push distance now allows the wire to be fully inserted if desired.
+Open `index.html` in a modern browser. The guidewire begins at the outer end of the introducer sheath. Use `W`/`S` or the up/down arrow keys to advance or retract the guidewire through the sheath and into the vessel. The sheath exits this branch with a fixed 30° anterior (+Z) angulation, and the push distance now allows the wire to be fully inserted if desired.
 
 Click the **Fluoroscopy** button to hide the vessel and display only the guidewire. Click again to return to the wireframe view.
 

--- a/simulator.js
+++ b/simulator.js
@@ -188,22 +188,22 @@ if (injSegmentSelect) {
 const segmentLength = 12;
 const nodeCount = 80;
 const initialWireLength = segmentLength * (nodeCount - 1);
-const initialInsert = segmentLength * 10;
+// Start with the guidewire tip at the sheath's outer end so it must traverse the introducer before entering the vessel
+const initialInsert = 0;
 
-const leftDir = {
-    x: (vessel.branchPoint.x - vessel.left.end.x) / vessel.left.length,
-    y: (vessel.branchPoint.y - vessel.left.end.y) / vessel.left.length,
-    z: (vessel.branchPoint.z - vessel.left.end.z) / vessel.left.length
+const sheathDir = {
+    x: (vessel.sheath.start.x - vessel.sheath.end.x) / vessel.sheath.length,
+    y: (vessel.sheath.start.y - vessel.sheath.end.y) / vessel.sheath.length,
+    z: (vessel.sheath.start.z - vessel.sheath.end.z) / vessel.sheath.length
 };
 
 const tailStart = {
-    x: vessel.left.end.x - leftDir.x * initialWireLength,
-    y: vessel.left.end.y - leftDir.y * initialWireLength,
-    z: vessel.left.end.z - leftDir.z * initialWireLength
-}; // start outside so the tip begins `initialInsert` inside the vessel
+    x: vessel.sheath.end.x - sheathDir.x * initialWireLength,
+    y: vessel.sheath.end.y - sheathDir.y * initialWireLength,
+    z: vessel.sheath.end.z - sheathDir.z * initialWireLength
+}; // begin outside so the wire travels through the sheath into the vessel
 
-
-const wire = new Guidewire(segmentLength, nodeCount, tailStart, leftDir, vessel, initialWireLength, undefined, undefined, initialInsert, { left: true });
+const wire = new Guidewire(segmentLength, nodeCount, tailStart, sheathDir, vessel, initialWireLength, undefined, undefined, initialInsert, { left: true });
 
 let advance = 0;
 document.addEventListener('keydown', e => {


### PR DESCRIPTION
## Summary
- Start the guidewire at the introducer sheath's outer tip so it must traverse the sheath before entering the vessel
- Update usage docs to reflect sheath traversal

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fd13b7b8832e8a3b6b65c29c8523