### PR TITLE
Center joystick knob after release

### DIFF
--- a/carm.js
+++ b/carm.js
@@ -138,6 +138,7 @@ export function setupCArmControls(camera, vessel, cameraRadius, previewGroup, pr
         });
         window.addEventListener('mouseup', () => {
             dragging = false;
+            joystickHandle.style.transform = 'translate(-50%, -50%)';
         });
     }
 }


### PR DESCRIPTION
## Summary
- Make the C-arm joystick handle snap back to neutral when the mouse button is released.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b303714fa0832ebd26bc9788fcfd39