### PR TITLE
Center joystick knob after release

### DIFF
--- a/carm.js
+++ b/carm.js
@@ -103,6 +103,30 @@ export function setupCArmControls(camera, vessel, cameraRadius, previewGroup, pr
         const handleRadius = joystickHandle.offsetWidth / 2;
         const maxDistance = joystick.offsetWidth / 2 - handleRadius;
         let dragging = false;
+        const handleTransition = 'transform 0.2s ease-out';
+        let speedX = 0;
+        let speedY = 0;
+        const minX = parseFloat(carmXSlider.min);
+        const maxX = parseFloat(carmXSlider.max);
+        const minY = parseFloat(carmYSlider.min);
+        const maxY = parseFloat(carmYSlider.max);
+        const maxSpeedX = (maxX - minX) / 2;
+        const maxSpeedY = (maxY - minY) / 2;
+        let lastTime = performance.now();
+
+        function step(now) {
+            const dt = (now - lastTime) / 1000;
+            lastTime = now;
+            if (speedX !== 0 || speedY !== 0) {
+                carmX = Math.min(Math.max(carmX + speedX * maxSpeedX * dt, minX), maxX);
+                carmY = Math.min(Math.max(carmY + speedY * maxSpeedY * dt, minY), maxY);
+                carmXSlider.value = carmX;
+                carmYSlider.value = carmY;
+                updateCamera();
+            }
+            requestAnimationFrame(step);
+        }
+        requestAnimationFrame(step);
 
         function updateFromJoystick(clientX, clientY) {
             const rect = joystick.getBoundingClientRect();
@@ -117,19 +141,13 @@ export function setupCArmControls(camera, vessel, cameraRadius, previewGroup, pr
             joystickHandle.style.transform = `translate(-50%, -50%) translate(${x}px, ${y}px)`;
             const normX = x / maxDistance;
             const normY = y / maxDistance;
-            const minX = parseFloat(carmXSlider.min);
-            const maxX = parseFloat(carmXSlider.max);
-            const minY = parseFloat(carmYSlider.min);
-            const maxY = parseFloat(carmYSlider.max);
-            carmX = minX + (normX + 1) / 2 * (maxX - minX);
-            carmY = minY + (1 - (normY + 1) / 2) * (maxY - minY);
-            carmXSlider.value = carmX;
-            carmYSlider.value = carmY;
-            updateCamera();
+            speedX = normX;
+            speedY = -normY;
         }
 
         joystick.addEventListener('mousedown', e => {
             dragging = true;
+            joystickHandle.style.transition = 'none';
             updateFromJoystick(e.clientX, e.clientY);
         });
         window.addEventListener('mousemove', e => {
@@ -138,6 +156,10 @@ export function setupCArmControls(camera, vessel, cameraRadius, previewGroup, pr
         });
         window.addEventListener('mouseup', () => {
             dragging = false;
+            joystickHandle.style.transition = handleTransition;
+            joystickHandle.style.transform = 'translate(-50%, -50%)';
+            speedX = 0;
+            speedY = 0;
         });
     }
 }


### PR DESCRIPTION
## Summary
- Make the C-arm joystick handle return to neutral smoothly after the mouse button is released.
- Drive C-arm translation speed by how far the joystick deviates from center rather than mapping directly to position.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b303714fa0832ebd26bc9788fcfd39