### PR TITLE
Simplify bone shader to render skeleton

### DIFF
--- a/boneModel.js
+++ b/boneModel.js
@@ -3,29 +3,15 @@ import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader.js';
 
 export function createBoneModel() {
     const material = new THREE.ShaderMaterial({
-        uniforms: {
-            thicknessMap: { value: null },
-            muBone: { value: 4.0 },
-            resolution: { value: new THREE.Vector2(1, 1) }
-        },
-        transparent: true,
-        depthWrite: false,
-        depthTest: false,
-        blending: THREE.AdditiveBlending,
         vertexShader: `
             void main() {
                 gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
             }
         `,
         fragmentShader: `
-            uniform sampler2D thicknessMap;
-            uniform float muBone;
-            uniform vec2 resolution;
             void main() {
-                vec2 uv = gl_FragCoord.xy / resolution;
-                float d = texture2D(thicknessMap, uv).r;
-                float absorb = 1.0 - exp(-muBone * d);
-                gl_FragColor = vec4(vec3(absorb), absorb);
+                // Render bones as solid white geometry
+                gl_FragColor = vec4(1.0);
             }
         `
     });

--- a/simulator.js
+++ b/simulator.js
@@ -167,7 +167,6 @@ scene.add(light);
 let vesselMaterial = new THREE.MeshStandardMaterial({color: 0x3366ff});
 let vesselGroup;
 const { group: boneGroup, material: boneMaterial } = createBoneModel();
-boneMaterial.uniforms.resolution.value.set(window.innerWidth, window.innerHeight);
 
 const { geometry, vessel } = generateVessel(140, 0); // deterministic branch parameters
 vesselGroup = new THREE.Group();
@@ -591,7 +590,6 @@ function animate(time) {
         renderer.setRenderTarget(thicknessTarget);
         renderer.render(thicknessScene, postCamera);
         renderer.setRenderTarget(null);
-        boneMaterial.uniforms.thicknessMap.value = thicknessTarget.texture;
 
         renderer.setRenderTarget(contrastTarget);
         withTransparentClear(renderer, () => {
@@ -649,6 +647,5 @@ window.addEventListener('resize', () => {
     frontDepthTarget.setSize(w, h);
     backDepthTarget.setSize(w, h);
     thicknessTarget.setSize(w, h);
-    boneMaterial.uniforms.resolution.value.set(w, h);
 });
 


### PR DESCRIPTION
## Summary
- Simplify bone shader to a constant white render
- Remove now-unused uniform wiring in simulator

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b30a80f8b8832ea3d88c9c7afb9347