### PR TITLE
Add C-arm Z height buttons

### DIFF
--- a/carm.js
+++ b/carm.js
@@ -8,6 +8,8 @@ export function setupCArmControls(camera, vessel, cameraRadius, previewGroup, pr
     const carmXSlider = document.getElementById('carmX');
     const carmYSlider = document.getElementById('carmY');
     const carmZSlider = document.getElementById('carmZ');
+    const carmZUpButton = document.getElementById('carmZUp');
+    const carmZDownButton = document.getElementById('carmZDown');
 
     const sliders = [
         carmYawSlider,
@@ -107,27 +109,56 @@ export function setupCArmControls(camera, vessel, cameraRadius, previewGroup, pr
 
         let speedX = 0;
         let speedY = 0;
+        let speedZ = 0;
         const minX = parseFloat(carmXSlider.min);
         const maxX = parseFloat(carmXSlider.max);
         const minY = parseFloat(carmYSlider.min);
         const maxY = parseFloat(carmYSlider.max);
+        const minZ = parseFloat(carmZSlider.min);
+        const maxZ = parseFloat(carmZSlider.max);
         const maxSpeedX = (maxX - minX) / 2;
         const maxSpeedY = (maxY - minY) / 2;
+        const maxSpeedZ = (maxZ - minZ) / 2;
         let lastTime = performance.now();
 
         function step(now) {
             const dt = (now - lastTime) / 1000;
             lastTime = now;
+            let updated = false;
             if (speedX !== 0 || speedY !== 0) {
                 carmX = Math.min(Math.max(carmX + speedX * maxSpeedX * dt, minX), maxX);
                 carmY = Math.min(Math.max(carmY + speedY * maxSpeedY * dt, minY), maxY);
                 carmXSlider.value = carmX;
                 carmYSlider.value = carmY;
+                updated = true;
+            }
+            if (speedZ !== 0) {
+                carmZ = Math.min(Math.max(carmZ + speedZ * maxSpeedZ * dt, minZ), maxZ);
+                carmZSlider.value = carmZ;
+                updated = true;
+            }
+            if (updated) {
                 updateCamera();
             }
             requestAnimationFrame(step);
         }
         requestAnimationFrame(step);
+
+        function startZ(dir) {
+            speedZ = dir;
+        }
+        function stopZ() {
+            speedZ = 0;
+        }
+        if (carmZUpButton && carmZDownButton) {
+            carmZUpButton.addEventListener('mousedown', () => startZ(1));
+            carmZDownButton.addEventListener('mousedown', () => startZ(-1));
+            window.addEventListener('mouseup', stopZ);
+            carmZUpButton.addEventListener('touchstart', e => { e.preventDefault(); startZ(1); });
+            carmZDownButton.addEventListener('touchstart', e => { e.preventDefault(); startZ(-1); });
+            window.addEventListener('touchend', stopZ);
+            window.addEventListener('touchcancel', stopZ);
+        }
 
 
         function updateFromJoystick(clientX, clientY) {

--- a/index.html
+++ b/index.html
@@ -41,11 +41,24 @@
             margin-bottom: 4px;
         }
 
+        #joystick-container {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+        #carmZButtons {
+            display: flex;
+            flex-direction: column;
+            margin-right: 10px;
+        }
+        #carmZButtons button {
+            margin: 2px 0;
+        }
         #joystick {
             position: relative;
             width: 120px;
             height: 120px;
-            margin: 10px auto;
+            margin: 10px;
             background-color: rgba(255, 255, 255, 0.1);
             border: 1px solid #666;
             border-radius: 50%;
@@ -267,8 +280,14 @@
     <div class="control-section">
         <div class="section-header"><span class="collapse-triangle">▼</span> C-arm</div>
         <div class="section-content">
-            <div id="joystick">
-                <div id="joystick-handle"></div>
+            <div id="joystick-container">
+                <div id="carmZButtons">
+                    <button id="carmZUp">Up</button>
+                    <button id="carmZDown">Down</button>
+                </div>
+                <div id="joystick">
+                    <div id="joystick-handle"></div>
+                </div>
             </div>
             <label class="parameter-label">C-arm yaw
                 <input id="carmYaw" type="range" min="-180" max="180" step="1" value="0">


### PR DESCRIPTION
## Summary
- Add Up/Down buttons next to joystick for C-arm height control
- Implement hold-to-move logic to adjust C-arm Z position continuously

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b31061215c832eb056fcf78ff8a712