### PR TITLE
Fade bone silhouette edges via normal-based transparency

### DIFF
--- a/boneModel.js
+++ b/boneModel.js
@@ -7,14 +7,18 @@ export function createBoneModel() {
         depthWrite: false,
 
         vertexShader: `
+            varying vec3 vNormal;
             void main() {
+                vNormal = normalize(normalMatrix * normal);
                 gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
             }
         `,
         fragmentShader: `
+            varying vec3 vNormal;
             void main() {
-                // Render bones as semi-transparent white geometry
-                gl_FragColor = vec4(1.0, 1.0, 1.0, 0.1);
+                // Fade bone edges by reducing opacity near the silhouette
+                float edgeFactor = abs(vNormal.z);
+                gl_FragColor = vec4(1.0, 1.0, 1.0, 0.1 * edgeFactor);
             }
         `
     });


### PR DESCRIPTION
## Summary
- Reduce bone opacity near silhouette edges for smoother X-ray appearance

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b43a442838832e957f4399777e5cd5