### PR TITLE
Start guidewire with tail outside the sheath

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -243,19 +243,21 @@ const wireDir = {
 // Place the tip slightly within the left branch
 const initialInsert = Math.max(sheathPath - 5, 0);
 
+// Offset the tail so the tip begins inside the vessel while the tail
+// remains outside the sheath
 const tailStart = {
-    x: vessel.sheath.end.x - wireDir.x * initialWireLength,
-    y: vessel.sheath.end.y - wireDir.y * initialWireLength,
-    z: vessel.sheath.end.z - wireDir.z * initialWireLength
-}; // start outside so the tip begins inside the vessel
+    x: vessel.sheath.end.x - wireDir.x * (initialWireLength - initialInsert),
+    y: vessel.sheath.end.y - wireDir.y * (initialWireLength - initialInsert),
+    z: vessel.sheath.end.z - wireDir.z * (initialWireLength - initialInsert)
+};
 
 
 const wire = new ElasticRod(nodeCount, segmentLength);
-let tailProgress = initialInsert;
-const maxInsert = tailProgress + initialWireLength;
-const minInsert = Math.min(tailProgress - initialWireLength, 0);
+let tailProgress = 0;
+const maxInsert = initialWireLength;
+const minInsert = -initialWireLength;
 for (let i = 0; i < wire.nodes.length; i++) {
-    const t = tailProgress + initialWireLength - segmentLength * i;
+    const t = initialWireLength - segmentLength * i;
     wire.nodes[i].x = tailStart.x + wireDir.x * t;
     wire.nodes[i].y = tailStart.y + wireDir.y * t;
     wire.nodes[i].z = tailStart.z + wireDir.z * t;


### PR DESCRIPTION
## Summary
- Position wire tail outside the sheath while keeping the tip inserted
- Initialize tail progress at zero to avoid starting with wire already advanced
- Remove remaining offset from node initialization so clamping and nodes start unadvanced

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b378b68b58832e94aa2114ab825644