### PR TITLE
Add voxel-based contrast flow simulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,6 +262,7 @@
     <button id="injectContrast">Inject</button>
     <button id="stopInjection" disabled>Stop Injection</button>
     <button id="modeToggle">Wireframe</button>
+    <label><input id="renderVoxels" type="checkbox"> Render voxels</label>
 </div>
 
 <div id="monitor">

--- a/simulator.js
+++ b/simulator.js
@@ -6,6 +6,7 @@ import { ContrastAgent, getContrastGeometry } from './contrastAgent.js';
 import { PatientMonitor } from './patientMonitor.js';
 import { initCArmPreview, cArmPreviewGroup, cArmPreviewGantry } from './carmPreview.js';
 import { createBoneModel } from './boneModel.js';
+import { VoxelContrastAgent, getVoxelMeshes } from './voxelContrastAgent.js';
 
 const canvas = document.getElementById('sim');
 const renderer = new THREE.WebGLRenderer({canvas, antialias: true});
@@ -202,6 +203,10 @@ const pivot = new THREE.Vector3(
 
 const contrast = new ContrastAgent(vessel);
 let contrastMesh = null;
+const voxelAgent = new VoxelContrastAgent(vessel, 2, 0.05);
+const voxelGroup = new THREE.Group();
+voxelGroup.visible = false;
+scene.add(voxelGroup);
 
 // Debug toggle to log contrast information
 const debugLabel = document.createElement('label');
@@ -289,6 +294,7 @@ const staticFricSlider = document.getElementById('staticFriction');
 const kineticFricSlider = document.getElementById('kineticFriction');
 const smoothIterSlider = document.getElementById('smoothIterations');
 const modeToggle = document.getElementById('modeToggle');
+const voxelRenderToggle = document.getElementById('renderVoxels');
 const injectButton = document.getElementById('injectContrast');
 const stopInjectButton = document.getElementById('stopInjection');
 const injRateSlider = document.getElementById('injRate');
@@ -324,6 +330,12 @@ const sliders = [
     injDurationSlider
 ];
 sliders.forEach(s => s.addEventListener('change', () => s.blur()));
+
+if (voxelRenderToggle) {
+    voxelRenderToggle.addEventListener('change', e => {
+        voxelGroup.visible = e.target.checked;
+    });
+}
 
 // Display current values next to each slider
 document.querySelectorAll('#controls input[type="range"], #carm-controls input[type="range"]').forEach(slider => {
@@ -526,6 +538,7 @@ function animate(time) {
     if (injecting) {
         const amt = Math.min(injectRate * dt, remainingVolume);
         contrast.inject(amt, injectSegmentIndex, false);
+        voxelAgent.inject(amt, injectSegmentIndex, false);
         totalDose += amt;
         doseDisplay.textContent = totalDose.toFixed(1) + ' ml';
         injectTime += dt;
@@ -536,6 +549,12 @@ function animate(time) {
         }
     }
     contrast.update(dt);
+    voxelAgent.update(dt);
+    if (voxelGroup.visible) {
+        voxelGroup.clear();
+        const voxMeshes = getVoxelMeshes(voxelAgent, 1e-4, true);
+        for (const m of voxMeshes) voxelGroup.add(m);
+    }
     if (contrast.debug) {
         const mainConc = contrast.concentration[injectSegmentIndex] / (contrast.volumes[injectSegmentIndex] || 1);
         const parentConc = parentIndex >= 0 ? contrast.concentration[parentIndex] / (contrast.volumes[parentIndex] || 1) : 0;

--- a/tests/voxelFlowDemo.js
+++ b/tests/voxelFlowDemo.js
@@ -1,0 +1,47 @@
+import { VoxelContrastAgent, getVoxelMeshes } from '../voxelContrastAgent.js';
+
+// Simple T-shaped vessel: a main segment that splits into two branches.
+const vessel = {
+    segments: [
+        {
+            start: { x: 0, y: 0, z: 0 },
+            end: { x: 0, y: 10, z: 0 },
+            radius: 2,
+            length: 10,
+            flowSpeed: 20
+        },
+        {
+            start: { x: 0, y: 10, z: 0 },
+            end: { x: 10, y: 20, z: 0 },
+            radius: 1,
+            length: 14.14,
+            flowSpeed: 10
+        },
+        {
+            start: { x: 0, y: 10, z: 0 },
+            end: { x: -10, y: 20, z: 0 },
+            radius: 1,
+            length: 14.14,
+            flowSpeed: 10
+        }
+    ],
+    // Map each segment to its downstream neighbours
+    segmentGraph: [ [1, 2], [], [] ]
+};
+
+const agent = new VoxelContrastAgent(vessel, 2, 0.05);
+agent.inject(1); // inject 1 ml into the first segment
+
+// Advance the simulation so contrast reaches the branches
+for (let frame = 0; frame < 5; frame++) {
+    agent.update(0.2);
+}
+
+const rightBranch = agent.getSegmentConcentrations(1);
+const leftBranch = agent.getSegmentConcentrations(2);
+console.log('Right branch receives contrast:', rightBranch.some(v => v > 0));
+console.log('Left branch receives contrast:', leftBranch.some(v => v > 0));
+
+const meshes = getVoxelMeshes(agent, 0, true);
+console.log('Wireframe mode:', meshes.length > 0 && meshes.every(m => m.material.wireframe));
+

--- a/voxelContrastAgent.js
+++ b/voxelContrastAgent.js
@@ -1,0 +1,223 @@
+import * as THREE from 'three';
+
+// Utility to build a simple voxel grid that fills cylindrical vessel segments.
+// Each segment is discretised into a 3D array of cubic voxels.  Voxels outside
+// the circular cross section are stored as null so we can reuse indexing across
+// the entire segment.
+export function voxelizeVessel(vessel, voxelSize = 5) {
+    const segments = [];
+    for (let s = 0; s < vessel.segments.length; s++) {
+        const seg = vessel.segments[s];
+        const start = new THREE.Vector3(seg.start.x, seg.start.y, seg.start.z);
+        const end = new THREE.Vector3(seg.end.x, seg.end.y, seg.end.z);
+        const dir = new THREE.Vector3().subVectors(end, start);
+        const length = dir.length();
+        if (!length) continue;
+        dir.normalize();
+
+        // Build an orthonormal basis for the cross section
+        const up = Math.abs(dir.y) < 0.99 ? new THREE.Vector3(0, 1, 0) : new THREE.Vector3(1, 0, 0);
+        const u = new THREE.Vector3().crossVectors(dir, up).normalize();
+        const v = new THREE.Vector3().crossVectors(dir, u).normalize();
+
+        const steps = Math.ceil(length / voxelSize);
+        const radialSteps = Math.ceil(seg.radius / voxelSize);
+        const width = radialSteps * 2 + 1;
+        const voxels = Array.from({ length: steps }, () =>
+            Array.from({ length: width }, () => new Array(width).fill(null)));
+
+        for (let i = 0; i < steps; i++) {
+            const center = start.clone().addScaledVector(dir, (i + 0.5) * voxelSize);
+            for (let y = -radialSteps; y <= radialSteps; y++) {
+                for (let x = -radialSteps; x <= radialSteps; x++) {
+                    const px = x * voxelSize;
+                    const py = y * voxelSize;
+                    if (px * px + py * py <= seg.radius * seg.radius) {
+                        const pos = center.clone()
+                            .addScaledVector(u, px)
+                            .addScaledVector(v, py);
+                        voxels[i][y + radialSteps][x + radialSteps] = {
+                            position: pos,
+                            concentration: 0
+                        };
+                    }
+                }
+            }
+        }
+        segments.push({
+            voxels,
+            width,
+            steps,
+            flowSpeed: seg.flowSpeed || 0,
+            voxelSize,
+            radius: seg.radius || 0,
+            children: vessel.segmentGraph ? [...(vessel.segmentGraph[s] || [])] : []
+        });
+    }
+    return { segments, voxelSize };
+}
+
+// Contrast transport on the voxelised vessel. Advection is handled along the
+// axial direction of each segment while diffusion is applied in all three axes
+// to spread concentration across the volume.
+export class VoxelContrastAgent {
+    constructor(vessel, voxelSize = 5, diffusion = 0.1) {
+        this.grid = voxelizeVessel(vessel, voxelSize);
+        this.diffusion = diffusion;
+    }
+
+    inject(volumeMl, segmentIndex = 0, atEnd = false) {
+        const seg = this.grid.segments[segmentIndex];
+        if (!seg) return;
+        const slice = atEnd ? seg.voxels[seg.voxels.length - 1] : seg.voxels[0];
+        // convert ml to mm^3 and distribute evenly
+        const totalVoxels = slice.flat().filter(v => v).length;
+        const volume = (volumeMl * 1000) / Math.max(1, totalVoxels);
+        for (const row of slice) {
+            for (const vox of row) {
+                if (vox) vox.concentration += volume;
+            }
+        }
+    }
+
+    update(dt) {
+        for (const seg of this.grid.segments) {
+            const voxels = seg.voxels;
+            const width = seg.width;
+            const steps = seg.steps;
+            const voxelSize = seg.voxelSize;
+            const dist = seg.flowSpeed * dt;
+            const frac = Math.min(1, Math.abs(dist) / voxelSize);
+            const dir = Math.sign(dist) || 1;
+
+            // advection along the axis
+            for (let i = dir > 0 ? steps - 1 : 0;
+                 dir > 0 ? i >= 0 : i < steps;
+                 i -= dir) {
+                const slice = voxels[i];
+                for (let y = 0; y < width; y++) {
+                    for (let x = 0; x < width; x++) {
+                        const vox = slice[y][x];
+                        if (!vox) continue;
+                        const moved = vox.concentration * frac;
+                        vox.concentration -= moved;
+                        const nextIdx = i + dir;
+                        if (nextIdx >= 0 && nextIdx < steps) {
+                            const dest = voxels[nextIdx][y][x];
+                            if (dest) dest.concentration += moved;
+                        } else if (seg.children && seg.children.length) {
+                            let totalRad = 0;
+                            for (const c of seg.children) {
+                                const child = this.grid.segments[c];
+                                if (child) totalRad += child.radius || 0;
+                            }
+                            for (const c of seg.children) {
+                                const child = this.grid.segments[c];
+                                if (!child || !totalRad) continue;
+                                const share = moved * (child.radius || 0) / totalRad;
+                                const destSlice = dir > 0 ? child.voxels[0] : child.voxels[child.steps - 1];
+                                const dest = destSlice[y] && destSlice[y][x];
+                                if (dest) dest.concentration += share;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // diffusion across all axes
+            if (this.diffusion > 0) {
+                const nextConc = voxels.map(slice =>
+                    slice.map(row => row.map(v => (v ? v.concentration : 0))));
+                for (let i = 0; i < steps; i++) {
+                    for (let y = 0; y < width; y++) {
+                        for (let x = 0; x < width; x++) {
+                            const vox = voxels[i][y][x];
+                            if (!vox) continue;
+                            let sum = vox.concentration;
+                            let count = 1;
+                            const add = (nx, ny, ni) => {
+                                const s = voxels[ni];
+                                if (!s) return;
+                                const n = s[ny] && s[ny][nx];
+                                if (n) {
+                                    sum += n.concentration;
+                                    count++;
+                                }
+                            };
+                            add(x + 1, y, i);
+                            add(x - 1, y, i);
+                            add(x, y + 1, i);
+                            add(x, y - 1, i);
+                            add(x, y, i + 1);
+                            add(x, y, i - 1);
+                            nextConc[i][y][x] = vox.concentration + this.diffusion * (sum / count - vox.concentration);
+                        }
+                    }
+                }
+                // write back
+                for (let i = 0; i < steps; i++) {
+                    for (let y = 0; y < width; y++) {
+                        for (let x = 0; x < width; x++) {
+                            const vox = voxels[i][y][x];
+                            if (vox) vox.concentration = nextConc[i][y][x];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Convenience to gather concentrations per segment for logging/visualisation
+    getSegmentConcentrations(segmentIndex) {
+        const seg = this.grid.segments[segmentIndex];
+        if (!seg) return [];
+        return seg.voxels.map(slice => {
+            let total = 0;
+            let count = 0;
+            for (const row of slice) {
+                for (const vox of row) {
+                    if (vox) {
+                        total += vox.concentration;
+                        count++;
+                    }
+                }
+            }
+            const voxelVol = seg.voxelSize ** 3;
+            return count ? total / (count * voxelVol) : 0;
+        });
+    }
+}
+
+// Generate a Three.js mesh for every voxel above a minimum concentration.
+// Pass `wireframe = true` to render the voxels as wireframe boxes instead of
+// solid cubes.
+export function getVoxelMeshes(agent, minConc = 1e-4, wireframe = false) {
+    if (!agent || !agent.grid) return [];
+    const size = agent.grid.voxelSize;
+    const geometry = new THREE.BoxGeometry(size, size, size);
+    const meshes = [];
+    for (const seg of agent.grid.segments) {
+        const width = seg.width;
+        const steps = seg.steps;
+        for (let i = 0; i < steps; i++) {
+            for (let y = 0; y < width; y++) {
+                for (let x = 0; x < width; x++) {
+                    const vox = seg.voxels[i][y][x];
+                    if (!vox || vox.concentration <= minConc) continue;
+                    const material = new THREE.MeshBasicMaterial({ wireframe });
+                    const color = new THREE.Color(
+                        vox.concentration,
+                        0,
+                        1 - vox.concentration
+                    );
+                    material.color.copy(color);
+                    const mesh = new THREE.Mesh(geometry, material);
+                    mesh.position.copy(vox.position);
+                    meshes.push(mesh);
+                }
+            }
+        }
+    }
+    return meshes;
+}
+


### PR DESCRIPTION
## Summary
- convert vessel voxelization to a true 3D grid
- diffuse contrast across axial neighbors for better resolution
- expose helper to generate voxel box meshes with optional wireframe mode
- verify wireframe option in voxel demo
- add Render voxels checkbox to toggle voxel mesh display in the simulator
- propagate voxel concentrations into downstream branches using radius-weighted distribution
- extend voxel demo with a branching vessel to confirm contrast reaches bifurcations

## Testing
- `npm test` (fails: no test specified)
- `node tests/voxelFlowDemo.js`


------
https://chatgpt.com/codex/tasks/task_e_68b430b93e98832ea140bbf2070266ec