### PR TITLE
Fix guidewire disappearing when moving camera

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -507,6 +507,7 @@ function updateWireMesh() {
         wirePositions[i * 3 + 2] = n.z;
     }
     wireGeometry.attributes.position.needsUpdate = true;
+    wireGeometry.computeBoundingSphere();
 }
 
 let lastTime = performance.now();


### PR DESCRIPTION
## Summary
- Recompute the guidewire geometry's bounding sphere each frame
- Prevent frustum culling from hiding the guidewire when camera tilts upward

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e0168ef4832ea4bae7abe4c23de9