### PR TITLE
Allow guidewire to exit vessel through sheath

### DIFF
--- a/physics/elasticRod.js
+++ b/physics/elasticRod.js
@@ -46,7 +46,9 @@ export function setWallFriction(staticCoeff, kineticCoeff) {
 
 // Project point n onto vessel segment seg.
 // Returns closest point (px,py,pz), offset vector (dx,dy,dz) from projection
-// to the node and the distance between them.
+// to the node and the distance between them. Also returns the unclamped
+// segment parameter t before restricting it to [0,1] so callers can detect
+// if the node lies beyond an endpoint.
 function projectOnSegment(n, seg) {
     const vx = seg.end.x - seg.start.x;
     const vy = seg.end.y - seg.start.y;
@@ -55,8 +57,8 @@ function projectOnSegment(n, seg) {
     const wy = n.y - seg.start.y;
     const wz = n.z - (seg.start.z || 0);
     const len2 = vx * vx + vy * vy + vz * vz;
-    let t = (wx * vx + wy * vy + wz * vz) / len2;
-    t = Math.max(0, Math.min(1, t));
+    const tRaw = (wx * vx + wy * vy + wz * vz) / len2;
+    const t = Math.max(0, Math.min(1, tRaw));
     const px = seg.start.x + vx * t;
     const py = seg.start.y + vy * t;
     const pz = (seg.start.z || 0) + vz * t;
@@ -64,7 +66,7 @@ function projectOnSegment(n, seg) {
     const dy = n.y - py;
     const dz = n.z - pz;
     const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
-    return { px, py, pz, dx, dy, dz, dist };
+    return { px, py, pz, dx, dy, dz, dist, t: tRaw };
 }
 
 export class ElasticRod {
@@ -289,6 +291,11 @@ export class ElasticRod {
                     best = p;
                     nearest = seg;
                 }
+            }
+            // If this node lies beyond the external end of the sheath, allow it
+            // to exit without applying collision or friction constraints.
+            if (nearest.isSheath && best.t < 0) {
+                continue;
             }
             const radius = nearest.radius;
             const penetration = best.dist - radius;

--- a/physics/elasticRod.test.js
+++ b/physics/elasticRod.test.js
@@ -127,3 +127,12 @@ pressRod.nodes[1].fy = 10; // force pushing into wall
 pressRod.collide(vessel);
 console.log('force friction vx', pressRod.nodes[1].vx.toFixed(4));
 console.assert(Math.abs(pressRod.nodes[1].vx) < 1e-6, 'pressing force should lock tangential motion');
+
+// node outside the introducer sheath should remain unconstrained
+const sheath = { segments: [{ start: { x: 0, y: 0, z: 0 }, end: { x: 1, y: 0, z: 0 }, radius: 1, isSheath: true }] };
+const exitRod = new ElasticRod(2, 1);
+exitRod.nodes[1].x = -0.5; // outside beyond sheath start
+exitRod.nodes[1].vx = -1;
+exitRod.collide(sheath);
+console.log('sheath exit x', exitRod.nodes[1].x.toFixed(4));
+console.assert(Math.abs(exitRod.nodes[1].x + 0.5) < 1e-6, 'node beyond sheath should not be clamped');

--- a/vesselGeometry.js
+++ b/vesselGeometry.js
@@ -182,11 +182,11 @@ export function generateVessel(branchLength = 140, branchAngleOffset = 0, sheath
         y: sheathStart.y + sheathDir.y * finalLength,
         z: sheathStart.z + sheathDir.z * finalLength
     };
-    vessel.sheath = { start: sheathStart, end: sheathEnd, radius: sheathRadius, length: finalLength };
+    vessel.sheath = { start: sheathStart, end: sheathEnd, radius: sheathRadius, length: finalLength, isSheath: true };
 
 
     // Add a segment for the sheath so the guidewire can traverse it
-    vessel.segments.push({ start: sheathStart, end: sheathEnd, radius: sheathRadius });
+    vessel.segments.push(vessel.sheath);
 
     // Compute segment lengths and volumes
     for (const seg of vessel.segments) {


### PR DESCRIPTION
## Summary
- Allow nodes beyond the sheath entry to bypass collision and friction so the guidewire can leave the vessel
- Expose raw segment parameter `t` from `projectOnSegment` and tag sheath geometry to detect exits
- Add regression test confirming nodes outside the sheath remain unconstrained

## Testing
- `node physics/elasticRod.test.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b4dee94d68832e80acf08b24bfad5e