### PR TITLE
Prevent guidewire withdrawal past sheath

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This prototype demonstrates a basic browser-based simulator for guiding a stiff 
 
 ## Usage
 
-Open `index.html` in a modern browser. Use `W`/`S` or the up/down arrow keys to advance or retract the guidewire through the introducer sheath positioned in the left branch. The sheath exits this branch with a fixed 30° anterior (+Z) angulation and now reaches the branch point so the wire can pass from outside the body into the vessel lumen.
+Open `index.html` in a modern browser. Use `W`/`S` or the up/down arrow keys to advance or retract the guidewire through the introducer sheath positioned in the left branch. Retraction stops when the wire's tip reaches the sheath entrance to keep it within the sheath. The sheath exits this branch with a fixed 30° anterior (+Z) angulation and now reaches the branch point so the wire can pass from outside the body into the vessel lumen.
 
 Click the **Fluoroscopy** button to hide the vessel and display only the guidewire. Click again to return to the wireframe view.
 

--- a/simulator.js
+++ b/simulator.js
@@ -263,7 +263,9 @@ const tailStart = {
 const wire = new ElasticRod(nodeCount, segmentLength);
 let tailProgress = 0;
 const maxInsert = initialWireLength;
-const minInsert = -initialWireLength;
+// Prevent withdrawing the wire past the sheath entrance so the tip
+// always remains within the sheath.
+const minInsert = 0;
 for (let i = 0; i < wire.nodes.length; i++) {
 
     const t = segmentLength * i;


### PR DESCRIPTION
## Summary
- Clamp guidewire retraction so the tip stays within the introducer sheath
- Document retraction limit in usage instructions

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node physics/elasticRod.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4e1f6cc04832eb89db5e5062433df