### PR TITLE
Align wire tail with sheath and raise sheath

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -232,11 +232,11 @@ if (injSegmentSelect) {
 const segmentLength = 5;
 const nodeCount = 80;
 const initialWireLength = segmentLength * (nodeCount - 1);
-// Direction from the sheath entrance toward the vessel
+// Direction along the sheath from its outer start toward the vessel
 const sheathDirVec = {
-    x: vessel.branchPoint.x - vessel.sheath.start.x,
-    y: vessel.branchPoint.y - vessel.sheath.start.y,
-    z: vessel.branchPoint.z - vessel.sheath.start.z
+    x: vessel.sheath.end.x - vessel.sheath.start.x,
+    y: vessel.sheath.end.y - vessel.sheath.start.y,
+    z: vessel.sheath.end.z - vessel.sheath.start.z
 };
 const sheathPath = Math.hypot(sheathDirVec.x, sheathDirVec.y, sheathDirVec.z) || 1;
 const wireDir = {

--- a/vesselGeometry.js
+++ b/vesselGeometry.js
@@ -168,7 +168,6 @@ export function generateVessel(branchLength = 140, branchAngleOffset = 0, sheath
     // Introducer sheath entering the vessel at a fixed 30° angle toward the
     // anterior (+Z) direction. The angle is measured relative to the left
     // branch's axis so the sheath presses against the vessel wall before
-
     // reaching the lumen at the distal branch end.
 
     const branchDir = new THREE.Vector3(
@@ -187,13 +186,18 @@ export function generateVessel(branchLength = 140, branchAngleOffset = 0, sheath
     // overridden by the caller.
     const autoLength = vessel.left.length * 0.5;
     const finalLength = sheathLength == null ? autoLength : sheathLength;
+    // Translate the entire sheath upward along +Y by 20 units
     const sheathStart = {
         x: vessel.left.end.x + outward.x * finalLength,
-        y: vessel.left.end.y + outward.y * finalLength,
+        y: vessel.left.end.y + outward.y * finalLength + 20,
         z: vessel.left.end.z + outward.z * finalLength
     };
     const sheathDir = outward.clone().negate();
-    const sheathEnd = { ...vessel.left.end };
+    const sheathEnd = {
+        x: vessel.left.end.x,
+        y: vessel.left.end.y + 20,
+        z: vessel.left.end.z
+    };
 
     vessel.sheath = { start: sheathStart, end: sheathEnd, radius: sheathRadius, length: finalLength, isSheath: true };
 


### PR DESCRIPTION
## Summary
- Remove branch direction negation so the sheath maintains its original orientation
- Shift sheath start and end 20 units upward along +Y, lifting the sheath without altering direction
- Guidewire orientation still derives from the sheath so the tail stays in line with the sheath axis

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node tests/elasticRod/straightening.js`
- `node tests/elasticRod/wallBend.js`
- `node tests/elasticRod/branchCollision.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4e7f266ac832e8e6a79f0c85e16cf