### PR TITLE
Improve vessel collision handling

### DIFF
--- a/physics/elasticRod.js
+++ b/physics/elasticRod.js
@@ -282,23 +282,31 @@ export class ElasticRod {
     collide(vessel, dt = 1) {
         if (!vessel || !vessel.segments || !vessel.segments.length) return;
         for (const n of this.nodes) {
-            let nearest = vessel.segments[0];
-            let best = projectOnSegment(n, nearest);
-            for (let i = 1; i < vessel.segments.length; i++) {
-                const seg = vessel.segments[i];
+            let bestInside = null;
+            let bestOutside = null;
+            for (const seg of vessel.segments) {
                 const p = projectOnSegment(n, seg);
-                if (p.dist < best.dist) {
-                    best = p;
-                    nearest = seg;
+                const pen = p.dist - seg.radius;
+                if (pen <= 0) {
+                    const depth = -pen;
+                    if (!bestInside || depth < bestInside.depth) {
+                        bestInside = { seg, p, depth, penetration: pen };
+                    }
+                } else if (!bestOutside || pen < bestOutside.penetration) {
+                    bestOutside = { seg, p, penetration: pen };
                 }
             }
+            const choice = bestInside || bestOutside;
+            if (!choice) continue;
+            const nearest = choice.seg;
+            const best = choice.p;
+            const penetration = choice.penetration;
             // If this node lies beyond the external end of the sheath, allow it
             // to exit without applying collision or friction constraints.
             if (nearest.isSheath && best.t < 0) {
                 continue;
             }
             const radius = nearest.radius;
-            const penetration = best.dist - radius;
             if (penetration > 0) {
                 const inv = 1 / (best.dist || 1);
                 const nx = best.dx * inv;

--- a/tests/elasticRod/branchCollision.js
+++ b/tests/elasticRod/branchCollision.js
@@ -2,7 +2,10 @@ import { ElasticRod } from '../../physics/elasticRod.js';
 import fs from 'fs';
 
 const log = [];
-const rod = new ElasticRod(20, 0.3, {
+// Start the rod before the branch so the tip must choose a path at the
+// bifurcation. A shorter initial length ensures the tip reaches the branch
+// after simulation begins rather than starting past it.
+const rod = new ElasticRod(10, 0.3, {
     logger: entry => log.push(entry)
 });
 
@@ -26,6 +29,12 @@ for (let i = 0; i < 400; i++) {
     rod.step(dt);
     rod.collide(vessel, dt);
 }
+
+// After navigating the branch the tip should have moved significantly upward.
+console.assert(
+    rod.nodes[rod.nodes.length - 1].y > 1.5,
+    'tip should enter the branch and move upward'
+);
 
 const logPath = new URL('./branch-collision.log', import.meta.url);
 fs.writeFileSync(logPath, JSON.stringify(log, null, 2));

--- a/tests/elasticRod/remoteSegmentInterference.js
+++ b/tests/elasticRod/remoteSegmentInterference.js
@@ -1,0 +1,31 @@
+import { ElasticRod } from '../../physics/elasticRod.js';
+
+// Rod initially placed within the main vessel far from a large-radius sheath
+const rod = new ElasticRod(5, 0.5);
+for (const n of rod.nodes) {
+    n.x += 2; // shift into the main vessel segment
+}
+
+// Vessel containing a distant sheath with a very large radius and a narrower main vessel
+const vessel = {
+    segments: [
+        { start: { x: 0, y: 0, z: 0 }, end: { x: 0, y: 1, z: 0 }, radius: 5 },
+        { start: { x: 1, y: 0, z: 0 }, end: { x: 10, y: 0, z: 0 }, radius: 1 }
+    ]
+};
+
+const dt = 0.01;
+for (let i = 0; i < 200; i++) {
+    // propel the tip forward along the main vessel
+    rod.nodes[rod.nodes.length - 1].vx = 1;
+    rod.step(dt);
+    rod.collide(vessel, dt);
+}
+
+// The tip should advance along the vessel rather than being pinned by the distant sheath
+console.assert(
+    rod.nodes[rod.nodes.length - 1].x > 4,
+    'tip should travel along the main vessel without interference'
+);
+
+console.log('final tip', rod.nodes[rod.nodes.length - 1]);


### PR DESCRIPTION
## Summary
- account for penetration into any vessel segment before applying collision response
- add branch navigation assertion and start rod upstream in branch test
- pick closest vessel wall when resolving collisions to avoid distant segments affecting the wire
- add regression test ensuring a remote sheath does not pin the rod

## Testing
- `node physics/elasticRod.test.js`
- `node tests/elasticRod/branchCollision.js`
- `node tests/elasticRod/remoteSegmentInterference.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4e752447c832ebe424c01da8b4b7b