### PR TITLE
Add vessel mesh BVH for rendering and collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Click the **Fluoroscopy** button to hide the vessel and display only the guidewi
 
 The vessel is generated deterministically. Branch length and angle offset use fixed defaults (140 units and 0 radians) and only change when explicitly provided to `generateVessel`. A short introducer sheath extends from the distal left branch with a 30° tilt against the vessel wall toward +Z.
 
+`vesselToGeometry(vessel)` converts the segment-based description into a `THREE.BufferGeometry` mesh with an acceleration structure used for both rendering and guidewire collisions.
+
 
 ## Tuning wall friction
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "three": "^0.160.0"
+        "three": "^0.160.0",
+        "three-mesh-bvh": "^0.9.1"
       }
     },
     "node_modules/three": {
@@ -17,6 +18,15 @@
       "resolved": "https://registry.npmjs.org/three/-/three-0.160.1.tgz",
       "integrity": "sha512-Bgl2wPJypDOZ1stAxwfWAcJ0WQf7QzlptsxkjYiURPz+n5k4RBDLsq+6f9Y75TYxn6aHLcWz+JNmwTOXWrQTBQ==",
       "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.9.1.tgz",
+      "integrity": "sha512-WNT+m9jGQgtp4YdtwEnl4oFylNVifRf7iphlwWdJ4bJu7oNkY0xHIyntep9OzHuR1hpe/pyAP840gB/EsYDJfg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "three": "^0.160.0"
+    "three": "^0.160.0",
+    "three-mesh-bvh": "^0.9.1"
   }
 }

--- a/physics/elasticRod.js
+++ b/physics/elasticRod.js
@@ -1,3 +1,5 @@
+import * as THREE from 'three';
+
 /**
  * ElasticRod models a slender elastic rod using a simple discrete formulation.
  *
@@ -280,7 +282,79 @@ export class ElasticRod {
 
     // Constrain nodes to stay inside the vessel geometry.
     collide(vessel, dt = 1) {
-        if (!vessel || !vessel.segments || !vessel.segments.length) return;
+        if (!vessel) return;
+        const geom = vessel.geometry;
+        const sheath = vessel.segments && vessel.segments.find(s => s.isSheath);
+        if (geom && geom.boundsTree) {
+            const p = new THREE.Vector3();
+            const target = new THREE.Vector3();
+            const normal = new THREE.Vector3();
+            for (const n of this.nodes) {
+                if (sheath) {
+                    const shProj = projectOnSegment(n, sheath);
+                    const radial = Math.sqrt(shProj.dx * shProj.dx + shProj.dy * shProj.dy + shProj.dz * shProj.dz);
+                    if (shProj.t < 0 && radial <= sheath.radius) continue;
+                }
+                p.set(n.x, n.y, n.z);
+                geom.boundsTree.closestPointToPoint(p, { point: target, normal });
+                const dx = p.x - target.x;
+                const dy = p.y - target.y;
+                const dz = p.z - target.z;
+                const dist = Math.sqrt(dx * dx + dy * dy + dz * dz);
+                if (normal.lengthSq() === 0) {
+                    const inv = 1 / (dist || 1);
+                    normal.set(dx * inv, dy * inv, dz * inv);
+                }
+                const dot = dx * normal.x + dy * normal.y + dz * normal.z;
+                const penetration = dot > 0 ? dist : -dist;
+                const nx = normal.x;
+                const ny = normal.y;
+                const nz = normal.z;
+                if (penetration > 0) {
+                    n.x = target.x;
+                    n.y = target.y;
+                    n.z = target.z;
+                    const vn = n.vx * nx + n.vy * ny + n.vz * nz;
+                    let tx = n.vx - vn * nx;
+                    let ty = n.vy - vn * ny;
+                    let tz = n.vz - vn * nz;
+                    const tMag = Math.sqrt(tx * tx + ty * ty + tz * tz);
+                    const normalForce = Math.max(0, n.fx * nx + n.fy * ny + n.fz * nz) + Math.abs(vn) * n.mass / dt;
+                    const staticLimit = wallStaticFriction * normalForce * dt / n.mass;
+                    const kineticLoss = wallKineticFriction * normalForce * dt / n.mass;
+                    if (tMag <= staticLimit) {
+                        tx = 0; ty = 0; tz = 0;
+                    } else {
+                        const scale = Math.max(0, tMag - kineticLoss) / (tMag || 1);
+                        tx *= scale; ty *= scale; tz *= scale;
+                    }
+                    n.vx = tx; n.vy = ty; n.vz = tz;
+                } else {
+                    const vn = n.vx * nx + n.vy * ny + n.vz * nz;
+                    let tx = n.vx - vn * nx;
+                    let ty = n.vy - vn * ny;
+                    let tz = n.vz - vn * nz;
+                    const tMag = Math.sqrt(tx * tx + ty * ty + tz * tz);
+                    const normalForce = Math.max(0, n.fx * nx + n.fy * ny + n.fz * nz);
+                    if (normalForce > 0 && tMag > 0) {
+                        const staticLimit = wallStaticFriction * normalForce * dt / n.mass;
+                        const kineticLoss = wallKineticFriction * normalForce * dt / n.mass;
+                        if (tMag <= staticLimit) {
+                            tx = 0; ty = 0; tz = 0;
+                        } else {
+                            const scale = Math.max(0, tMag - kineticLoss) / (tMag || 1);
+                            tx *= scale; ty *= scale; tz *= scale;
+                        }
+                        n.vx = tx; n.vy = ty; n.vz = tz;
+                    }
+                }
+            }
+            if (this.smoothingIterations > 0) {
+                this.laplacianSmooth(dt);
+            }
+            return;
+        }
+        if (!vessel.segments || !vessel.segments.length) return;
         for (const n of this.nodes) {
 
             let bestInside = null;

--- a/vesselGeometry.js
+++ b/vesselGeometry.js
@@ -1,97 +1,31 @@
 import * as THREE from 'three';
-import { Brush, Evaluator, ADDITION } from 'https://unpkg.com/three-bvh-csg@0.0.17/build/index.module.js';
+import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+import { MeshBVH } from 'three-mesh-bvh';
 
-function verifyManifold(geometry) {
-    const index = geometry.index;
-    if (!index) return 1;
-    const count = geometry.attributes.position.count;
-    const visited = new Array(count).fill(false);
-    const adj = Array.from({length: count}, () => []);
-    const arr = index.array;
-    for (let i = 0; i < arr.length; i += 3) {
-        const a = arr[i], b = arr[i + 1], c = arr[i + 2];
-        adj[a].push(b, c);
-        adj[b].push(a, c);
-        adj[c].push(a, b);
+export function vesselToGeometry(vessel, radialSegments = 16) {
+    const geoms = [];
+    const yAxis = new THREE.Vector3(0, 1, 0);
+    for (const seg of vessel.segments || []) {
+        const start = new THREE.Vector3(seg.start.x, seg.start.y, seg.start.z);
+        const end = new THREE.Vector3(seg.end.x, seg.end.y, seg.end.z);
+        const dir = new THREE.Vector3().subVectors(end, start);
+        const length = dir.length();
+        if (!length) continue;
+        const geom = new THREE.CylinderGeometry(seg.radius, seg.radius, length, radialSegments, 1, true);
+        const quat = new THREE.Quaternion().setFromUnitVectors(yAxis, dir.clone().normalize());
+        geom.applyQuaternion(quat);
+        const mid = new THREE.Vector3().addVectors(start, end).multiplyScalar(0.5);
+        geom.translate(mid.x, mid.y, mid.z);
+        geoms.push(geom);
     }
-    let components = 0;
-    const stack = [];
-    for (let i = 0; i < count; i++) {
-        if (!visited[i]) {
-            components++;
-            stack.push(i);
-            visited[i] = true;
-            while (stack.length) {
-                const v = stack.pop();
-                for (const n of adj[v]) {
-                    if (!visited[n]) {
-                        visited[n] = true;
-                        stack.push(n);
-                    }
-                }
-            }
-        }
+    if (!geoms.length) return new THREE.BufferGeometry();
+    const merged = mergeGeometries(geoms, true);
+    merged.computeVertexNormals();
+    merged.computeBoundsTree?.();
+    if (!merged.boundsTree) {
+        merged.boundsTree = new MeshBVH(merged);
     }
-    if (components > 1) {
-        console.warn(`Geometry has ${components} disconnected components`);
-    }
-    return components;
-}
-
-function createTaperedTube(path, tubularSegments, radialSegments, startRadius, endRadius) {
-    const geometry = new THREE.TubeGeometry(path, tubularSegments, 1, radialSegments, false);
-    const pos = geometry.attributes.position;
-    const normals = geometry.attributes.normal;
-    const segments = tubularSegments + 1;
-    const radials = radialSegments + 1;
-    for (let i = 0; i < segments; i++) {
-        const t = i / tubularSegments;
-        const r = startRadius + (endRadius - startRadius) * t;
-        for (let j = 0; j < radials; j++) {
-            const idx = i * radials + j;
-            pos.setX(idx, pos.getX(idx) + normals.getX(idx) * (r - 1));
-            pos.setY(idx, pos.getY(idx) + normals.getY(idx) * (r - 1));
-            pos.setZ(idx, pos.getZ(idx) + normals.getZ(idx) * (r - 1));
-        }
-    }
-    pos.needsUpdate = true;
-    geometry.computeVertexNormals();
-    return geometry;
-}
-
-function createBranchingSegment(mainRadius, branchRadius, branchPointY, branchLength, blend, branchAngleOffset) {
-    const trunkHeight = Math.abs(branchPointY);
-    const trunkGeom = new THREE.CylinderGeometry(mainRadius, mainRadius, trunkHeight, 16, 1, true);
-    trunkGeom.translate(0, branchPointY / 2, 0);
-
-    const angleBase = Math.PI / 6;
-    const makeCurve = angle => new THREE.QuadraticBezierCurve3(
-        new THREE.Vector3(0, branchPointY, 0),
-        new THREE.Vector3(Math.sin(angle) * blend, branchPointY - blend, 0),
-        new THREE.Vector3(Math.sin(angle) * (blend + branchLength), branchPointY - (blend + branchLength), 0)
-    );
-
-    const rightCurve = makeCurve(angleBase + branchAngleOffset);
-    const leftCurve = makeCurve(-angleBase - branchAngleOffset);
-
-    const rightGeom = createTaperedTube(rightCurve, 64, 16, mainRadius, branchRadius);
-    const leftGeom = createTaperedTube(leftCurve, 64, 16, mainRadius, branchRadius);
-
-    const trunkBrush = new Brush(trunkGeom);
-    const rightBrush = new Brush(rightGeom);
-    const leftBrush = new Brush(leftGeom);
-    trunkBrush.updateMatrixWorld();
-    rightBrush.updateMatrixWorld();
-    leftBrush.updateMatrixWorld();
-
-    const evaluator = new Evaluator();
-    const result1 = evaluator.evaluate(trunkBrush, rightBrush, ADDITION);
-    result1.updateMatrixWorld();
-    const result = evaluator.evaluate(result1, leftBrush, ADDITION);
-    const geometry = result.geometry;
-    geometry.computeVertexNormals();
-    verifyManifold(geometry);
-    return geometry;
+    return merged;
 }
 
 /**
@@ -188,13 +122,12 @@ export function generateVessel(branchLength = 140, branchAngleOffset = 0, sheath
     const finalLength = sheathLength == null ? autoLength : sheathLength;
     // Translate the entire sheath upward along +Y by 20 units
     const sheathStart = {
-        x: vessel.left.end.x + outward.x * finalLength +10,
+        x: vessel.left.end.x + outward.x * finalLength + 10,
         y: vessel.left.end.y + outward.y * finalLength + 20,
         z: vessel.left.end.z + outward.z * finalLength
     };
-    const sheathDir = outward.clone().negate();
     const sheathEnd = {
-        x: vessel.left.end.x +10,
+        x: vessel.left.end.x + 10,
         y: vessel.left.end.y + 20,
         z: vessel.left.end.z
     };
@@ -292,31 +225,8 @@ export function generateVessel(branchLength = 140, branchAngleOffset = 0, sheath
     }
     vessel.flow = flow;
 
-    const geometry = createBranchingSegment(mainRadius, branchRadius, branchPointY, branchLength, blend, branchAngleOffset);
-
-    // Build geometry for the introducer sheath
-    const sheathGeom = new THREE.CylinderGeometry(sheathRadius, sheathRadius, vessel.sheath.length, 16, 1, true);
-    const quat = new THREE.Quaternion().setFromUnitVectors(new THREE.Vector3(0, 1, 0), sheathDir);
-    sheathGeom.applyQuaternion(quat);
-    const mid = new THREE.Vector3(
-        sheathStart.x + sheathDir.x * vessel.sheath.length / 2,
-        sheathStart.y + sheathDir.y * vessel.sheath.length / 2,
-        sheathStart.z + sheathDir.z * vessel.sheath.length / 2
-
-    );
-    sheathGeom.translate(mid.x, mid.y, mid.z);
-
-    const evaluator = new Evaluator();
-    const vesselBrush = new Brush(geometry);
-    vesselBrush.updateMatrixWorld();
-    const sheathBrush = new Brush(sheathGeom);
-    sheathBrush.updateMatrixWorld();
-    const merged = evaluator.evaluate(vesselBrush, sheathBrush, ADDITION);
-    merged.updateMatrixWorld();
-    const finalGeometry = merged.geometry;
-    finalGeometry.computeVertexNormals();
-    verifyManifold(finalGeometry);
-
-    return { vessel, geometry: finalGeometry };
+    const geometry = vesselToGeometry(vessel);
+    vessel.geometry = geometry;
+    return { vessel, geometry };
 }
 


### PR DESCRIPTION
## Summary
- build a BVH-backed `THREE.BufferGeometry` from vessel segments and attach it to the vessel
- drive guidewire collisions with the vessel mesh BVH, falling back to segment checks when needed
- document mesh-based geometry and add `three-mesh-bvh` dependency

## Testing
- `node -e "import('./vesselGeometry.js').then(m=>{const {vessel, geometry}=m.generateVessel(); console.log('segments', vessel.segments.length, 'verts', geometry.attributes.position.count, 'hasTree', Boolean(geometry.boundsTree));})"`
- `node physics/elasticRod.test.js`
- `node tests/elasticRod/branchCollision.js`
- `node -e "import('./vesselGeometry.js').then(async m=>{const {vessel}=m.generateVessel(); const {ElasticRod}=await import('./physics/elasticRod.js'); const rod=new ElasticRod(2,1); rod.nodes[1].x=vessel.radius*2; rod.collide(vessel); console.log('postX', rod.nodes[1].x.toFixed(2));})"`

------
https://chatgpt.com/codex/tasks/task_e_68b4ec969dac832e9cb5cbbd23789624