### PR TITLE
Fix branch radius at bifurcation for seamless vessel mesh

### DIFF
--- a/vesselGeometry.js
+++ b/vesselGeometry.js
@@ -106,7 +106,13 @@ export function generateVessel(branchLength = 140, branchAngleOffset = 0, sheath
                 y: tt * tt * p0.y + 2 * tt * t * p1.y + t * t * endPoint.y,
                 z: tt * tt * p0.z + 2 * tt * t * p1.z + t * t * endPoint.z
             };
-            const r = mainRadius + (branchRadius - mainRadius) * t;
+            // Use the previous step's t value when interpolating the radius so
+            // the branch starts with the same radius as the main vessel. The
+            // original implementation used the current step's t which resulted
+            // in a slightly smaller first segment and left a visible gap where
+            // the branches meet the bifurcation.
+            const rStep = (i - 1) / steps;
+            const r = mainRadius + (branchRadius - mainRadius) * rStep;
             vessel.segments.push({ start: prev, end: p, radius: r });
             prev = p;
         }


### PR DESCRIPTION
## Summary
- ensure branch curve starts with main vessel radius so branches properly join bifurcation

## Testing
- `node tests/elasticRod/branchCollision.js`
- `node tests/elasticRod/remoteSegmentInterference.js`
- `node tests/elasticRod/straightening.js`
- `node tests/elasticRod/visualize.js` *(fails: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader)*
- `node tests/elasticRod/wallBend.js`
- `node tests/voxelFlowDemo.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6249a3a74832eab715319e2515ec4