### PR TITLE
Open sheath end to allow guidewire withdrawal

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This prototype demonstrates a basic browser-based simulator for guiding a stiff 
 
 ## Usage
 
-Open `index.html` in a modern browser. Use `W`/`S` or the up/down arrow keys to advance or retract the guidewire through the introducer sheath positioned at the distal end of the left branch. Retraction stops when the wire's tip reaches the sheath entrance to keep it within the sheath. The sheath enters this branch at a 30° angle against the vessel wall, tilting toward the anterior (+Z) direction so the wire can pass from outside the body into the vessel lumen.
+Open `index.html` in a modern browser. Use `W`/`S` or the up/down arrow keys to advance or retract the guidewire through the introducer sheath positioned at the distal end of the left branch. The sheath's outer end is open so the wire can be fully withdrawn. It enters this branch at a 30° angle against the vessel wall, tilting toward the anterior (+Z) direction so the wire can pass from outside the body into the vessel lumen.
 
 
 Click the **Fluoroscopy** button to hide the vessel and display only the guidewire. Click again to return to the wireframe view.

--- a/simulator.js
+++ b/simulator.js
@@ -263,9 +263,9 @@ const tailStart = {
 const wire = new ElasticRod(nodeCount, segmentLength);
 let tailProgress = 0;
 const maxInsert = initialWireLength;
-// Prevent withdrawing the wire past the sheath entrance so the tip
-// always remains within the sheath.
-const minInsert = 0;
+// Permit fully retracting the wire by allowing negative insertion values.
+// This lets the tip pass back through the sheath's open outer end.
+const minInsert = -initialWireLength;
 for (let i = 0; i < wire.nodes.length; i++) {
 
     const t = segmentLength * i;

--- a/vesselGeometry.js
+++ b/vesselGeometry.js
@@ -30,7 +30,11 @@ export function vesselToGeometry(vessel, radialSegments = 16) {
         const brush = new Brush(geom);
         brush.updateMatrixWorld();
         result = result ? evaluator.evaluate(result, brush, ADDITION) : brush;
-        addNode(seg.start, seg.radius);
+        // Leave the outer end of the introducer sheath uncapped so the
+        // guidewire can be withdrawn completely. Skip adding a blending sphere
+        // at the sheath's start but retain one at its inner end where it
+        // connects to the vessel.
+        if (!seg.isSheath) addNode(seg.start, seg.radius);
         addNode(seg.end, seg.radius);
     }
     // Fuse all touching segments by adding a sphere at each node with radius


### PR DESCRIPTION
## Summary
- Leave introducer sheath's outer end uncapped so the guidewire can exit completely.
- Permit negative insertion to fully retract the wire through the open sheath.
- Update usage docs to note the sheath's open end and full withdrawal capability.

## Testing
- `node physics/elasticRod.test.js` *(fails: static friction should zero tangential velocity, normal velocity should be zero after collision, kinetic friction should reduce tangential velocity, pressing force should lock tangential motion)*
- `node tests/elasticRod/branchCollision.js`
- `node tests/elasticRod/remoteSegmentInterference.js`
- `node tests/elasticRod/wallBend.js`
- `node tests/elasticRod/straightening.js`


------
https://chatgpt.com/codex/tasks/task_e_68b62e2d6724832ea21684397cd008c2