### PR TITLE
Keep sheath external end open

### DIFF
--- a/vesselGeometry.js
+++ b/vesselGeometry.js
@@ -30,8 +30,15 @@ export function vesselToGeometry(vessel, radialSegments = 16) {
         const brush = new Brush(geom);
         brush.updateMatrixWorld();
         result = result ? evaluator.evaluate(result, brush, ADDITION) : brush;
-        addNode(seg.start, seg.radius);
-        addNode(seg.end, seg.radius);
+        if (seg.isSheath) {
+            // Leave the outer sheath entrance open by omitting a blending sphere.
+            // Only add a node at the vessel-facing end so it fuses seamlessly with
+            // the branch while keeping the external end uncapped.
+            addNode(seg.end, seg.radius);
+        } else {
+            addNode(seg.start, seg.radius);
+            addNode(seg.end, seg.radius);
+        }
     }
     // Fuse all touching segments by adding a sphere at each node with radius
     // equal to the largest adjoining segment radius. This guarantees the


### PR DESCRIPTION
## Summary
- Avoid closing outer introducer sheath entrance by skipping node blend at sheath start in vessel geometry generation

## Testing
- `node physics/elasticRod.test.js` *(fails: Assertion failed: static friction should zero tangential velocity)*
- `node tests/elasticRod/remoteSegmentInterference.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b86d160b2c832e885e748cdb50ca1d