### PR TITLE
Add damping and energy tracking to elastic rod

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ relax sharp bends. Default values for bending stiffness and the number of
 smoothing iterations may be configured via the `setBendingStiffness` and
 `setSmoothingIterations` functions exported from `physics/elasticRod.js`.
 
+The solver also exposes `setInternalDamping` and `setVelocityDamping` helpers.
+Internal damping acts as a velocity-proportional drag on each node so that the
+rod's kinetic energy decays, while velocity damping applies an exponential
+decay to free motion during constraint projection. Together they prevent the
+guidewire from oscillating indefinitely and drive it toward a static
+equilibrium. After each simulation `step` the rod reports its kinetic,
+potential and total energy via the `energy` property and through the optional
+logger callback, making it easy to monitor convergence toward equilibrium.
+
 ## Simulation logging and tests
 
 `ElasticRod` accepts an optional `logger` callback. When provided, the callback

--- a/src/physics/elasticRod.js
+++ b/src/physics/elasticRod.js
@@ -27,6 +27,8 @@ import * as THREE from 'three';
 // higher default stiffness gives stronger self-straightening
 let defaultBendingStiffness = 20;
 let defaultSmoothingIterations = 0;
+let defaultInternalDamping = 2.5;
+let defaultVelocityDamping = 4;
 
 // Coefficients for static and kinetic friction against vessel walls.
 // Values are relative to the normal component of velocity.
@@ -39,6 +41,14 @@ export function setBendingStiffness(value) {
 
 export function setSmoothingIterations(value) {
     defaultSmoothingIterations = value;
+}
+
+export function setInternalDamping(value) {
+    defaultInternalDamping = value;
+}
+
+export function setVelocityDamping(value) {
+    defaultVelocityDamping = value;
 }
 
 export function setWallFriction(staticCoeff, kineticCoeff) {
@@ -77,12 +87,17 @@ export class ElasticRod {
         bendingStiffness = defaultBendingStiffness,
         smoothingIterations = defaultSmoothingIterations,
         logger = null,
+        internalDamping = defaultInternalDamping,
+        velocityDamping = defaultVelocityDamping,
     } = {}) {
         this.segmentLength = segmentLength;
         this.nodes = [];
         this.smoothingIterations = smoothingIterations;
         this.logger = logger;
         this.iteration = 0;
+        this.internalDamping = internalDamping;
+        this.velocityDamping = velocityDamping;
+        this.energy = { kinetic: 0, potential: 0, total: 0 };
         for (let i = 0; i < count; i++) {
             const x = i * segmentLength;
             const y = 0, z = 0;
@@ -183,6 +198,18 @@ export class ElasticRod {
         }
     }
 
+    applyInternalDamping() {
+        if (!this.internalDamping) return;
+        const damping = this.internalDamping;
+        for (const n of this.nodes) {
+            if (n.pinned) continue;
+            const mass = n.mass;
+            n.fx -= damping * mass * n.vx;
+            n.fy -= damping * mass * n.vy;
+            n.fz -= damping * mass * n.vz;
+        }
+    }
+
     // Integrate positions and velocities using semi-implicit Euler
     integrate(dt) {
         for (const n of this.nodes) {
@@ -256,11 +283,12 @@ export class ElasticRod {
         }
 
         // velocity damping
+        const damping = Math.exp(-Math.max(0, this.velocityDamping) * dt);
         for (const n of this.nodes) {
             if (n.pinned) continue;
-            n.vx *= 0.98;
-            n.vy *= 0.98;
-            n.vz *= 0.98;
+            n.vx *= damping;
+            n.vy *= damping;
+            n.vz *= damping;
         }
 
         // optional Laplacian smoothing after constraints
@@ -377,18 +405,55 @@ export class ElasticRod {
         }
     }
 
+    computeKineticEnergy() {
+        let sum = 0;
+        for (const n of this.nodes) {
+            if (n.pinned) continue;
+            const v2 = n.vx * n.vx + n.vy * n.vy + n.vz * n.vz;
+            sum += 0.5 * n.mass * v2;
+        }
+        return sum;
+    }
+
+    computePotentialEnergy() {
+        let sum = 0;
+        const L = this.segmentLength;
+        if (this.nodes.length < 3) return sum;
+        for (let i = 1; i < this.nodes.length - 1; i++) {
+            const n = this.nodes[i];
+            const kx = n.kx;
+            const ky = n.ky;
+            const kz = n.kz;
+            const k2 = kx * kx + ky * ky + kz * kz;
+            sum += 0.5 * n.bendingStiffness * k2 * L;
+        }
+        return sum;
+    }
+
+    computeEnergies() {
+        const kinetic = this.computeKineticEnergy();
+        const potential = this.computePotentialEnergy();
+        return { kinetic, potential, total: kinetic + potential };
+    }
+
     step(dt) {
         this.resetForces();
         this.updateCurvature();
         this.accumulateBendingForces();
+        this.applyInternalDamping();
         this.integrate(dt);
         this.solveConstraints(dt);
+        this.updateCurvature();
+        this.energy = this.computeEnergies();
         this.iteration++;
         if (this.logger) {
             this.logger({
                 iteration: this.iteration,
                 curvature: this.averageCurvature(),
                 length: this.computeLength(),
+                kineticEnergy: this.energy.kinetic,
+                potentialEnergy: this.energy.potential,
+                totalEnergy: this.energy.total,
             });
         }
     }

--- a/tests/elasticRod.test.js
+++ b/tests/elasticRod.test.js
@@ -6,11 +6,21 @@ import { MeshBVH } from 'three-mesh-bvh';
 const rod = new ElasticRod(5, 1, { mass: 1, bendingStiffness: 0.5 });
 // introduce a perturbation
 rod.nodes[2].y = 0.5;
+rod.updateCurvature();
+const initialEnergy = rod.computeEnergies();
 
 const dt = 0.01;
 for (let i = 0; i < 200; i++) {
     rod.step(dt);
 }
+const finalEnergy = rod.energy;
+
+console.log('initial total energy', initialEnergy.total.toFixed(6));
+console.log('final kinetic energy', finalEnergy.kinetic.toFixed(6));
+console.log('final potential energy', finalEnergy.potential.toFixed(6));
+console.log('final total energy', finalEnergy.total.toFixed(6));
+console.assert(finalEnergy.total < initialEnergy.total * 0.1, 'energy should dissipate toward equilibrium');
+console.assert(finalEnergy.kinetic < 1e-3, 'kinetic energy should be near zero at equilibrium');
 
 let maxErr = 0;
 const L = rod.segmentLength;


### PR DESCRIPTION
## Summary
- add configurable internal and velocity damping to the elastic rod to bleed off oscillations
- compute kinetic and potential energy for each step and expose the values for logging and monitoring
- document the new controls and extend the elastic rod test to assert that energy dissipates toward equilibrium

## Testing
- node tests/elasticRod.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d54094aadc832ea66a38101b7afa0e