### PR TITLE
Improve fluoroscopy shader realism and add Three.js import map

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,6 +288,14 @@
 <div id="perfStats">FPS: 0 | Mem: N/A</div>
 <div id="joystick-container"><div id="joystick"></div></div>
 
+<script type="importmap">
+{
+    "imports": {
+        "three": "./node_modules/three/build/three.module.js",
+        "three/": "./node_modules/three/"
+    }
+}
+</script>
 
 <script type="module" src="./simulator.js"></script>
 </body>

--- a/simulator.js
+++ b/simulator.js
@@ -68,12 +68,12 @@ const displayMaterial = new THREE.ShaderMaterial({
     uniforms: {
         uTexture: { value: previousTarget.texture },
         contrastTexture: { value: contrastTarget.texture },
-        gray: { value: new THREE.Color(0xC3C3C3) },
+        gray: { value: new THREE.Color(0x9a9a9a) },
         fluoroscopy: { value: false },
         time: { value: 0 },
         noiseLevel: { value: 0.05 },
         // Lower default bone opacity so bones appear less prominent
-        boneOpacity: { value: 0.5 }
+        boneOpacity: { value: 0.35 }
 
     },
     vertexShader: `
@@ -99,13 +99,20 @@ const displayMaterial = new THREE.ShaderMaterial({
         void main() {
             vec4 tex = texture2D(uTexture, vUv);
             if (fluoroscopy) {
-                float intensity = max(tex.r, max(tex.g, tex.b)) * boneOpacity;
+                float luma = dot(tex.rgb, vec3(0.2126, 0.7152, 0.0722));
+                float intensity = smoothstep(0.05, 0.75, luma) * boneOpacity;
                 float noise = random(vUv * 100.0) - 0.5;
                 intensity += noise * noiseLevel;
                 intensity = clamp(intensity, 0.0, 1.0);
                 vec4 cSample = texture2D(contrastTexture, vUv);
                 float contrast = clamp((cSample.r + cSample.b) * 2.0, 0.0, 1.0);
-                vec3 color = mix(gray, vec3(1.0), intensity);
+                // Real fluoroscopy usually has a dark detector background and
+                // off-white bony structures instead of pure white clipping.
+                vec3 detector = vec3(0.08);
+                vec3 boneTint = vec3(0.86);
+                vec3 color = mix(detector, mix(gray, boneTint, intensity), 0.95);
+                float vignette = smoothstep(0.95, 0.25, distance(vUv, vec2(0.5)));
+                color *= vignette;
                 gl_FragColor = vec4(mix(color, vec3(0.0), contrast), 1.0);
             } else {
                 gl_FragColor = tex;
@@ -595,4 +602,3 @@ window.addEventListener('resize', () => {
     accumulateTarget1.setSize(w, h);
     accumulateTarget2.setSize(w, h);
 });
-


### PR DESCRIPTION
### Motivation
- Make the fluoroscopy display more realistic by reducing bone prominence, using luminance-based bone detection, and simulating detector background and vignette effects.
- Ensure the browser can resolve Three.js ES module imports when loading `simulator.js` as a module.

### Description
- Add an `importmap` entry in `index.html` mapping `three` and `three/` to `./node_modules/three/` so the module loader can locate Three.js files in the browser.
- Update `displayMaterial` uniforms in `simulator.js` to change `gray` from `0xC3C3C3` to `0x9a9a9a` and lower `boneOpacity` from `0.5` to `0.35` to make bones less prominent.
- Replace the fluoroscopy intensity calculation with a luminance-based approach using `dot(tex.rgb, vec3(0.2126, 0.7152, 0.0722))` and `smoothstep`, and adjust color mixing to use a dark `detector` background, an off-white `boneTint`, and a vignette for realism.
- Add clarifying comments in the shader and small formatting cleanup at the end of the file.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f11c520880832eba71b2293190746d)