### PR TITLE
[codex] Ulepsz shader fluoroskopii

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Endovascular Trainer</title>
-    <link rel="stylesheet" href="style.css?v=20260614guidewireinside1">
+    <link rel="stylesheet" href="style.css?v=20260615fluoro18">
 </head>
 <body>
 <canvas id="sim"></canvas>
@@ -11,6 +11,10 @@
     <div id="insertedLength">0 cm</div>
     <div id="catheterLength">Pigtail 0 cm</div>
     <div id="currentDose">0 ml</div>
+    <div id="xrayTechnique" class="xray-technique">
+        <span id="currentKV">72 kV</span>
+        <span id="currentMA">3.0 mA</span>
+    </div>
     <div id="guidewireResistanceStatus" class="guidewire-resistance hidden">
         <div class="guidewire-resistance-header">
             <span id="guidewireResistanceReason">Opór na prowadniku</span>
@@ -67,12 +71,41 @@
     <div class="control-section">
         <div class="section-header collapsed"><span class="collapse-triangle">▼</span> Imaging</div>
         <div class="section-content hidden">
+            <button id="autoExposureToggle" class="imaging-toggle active" type="button">Auto exposure: On</button>
             <label class="parameter-label">Persistence
                 <input id="persistence" type="range" min="0.25" max="0.99" step="0.01" value="0.35">
                 <span></span>
             </label>
+            <label class="parameter-label">Pulse fluoro
+                <select id="pulseRate">
+                    <option value="7.5">7.5 fps</option>
+                    <option value="15" selected>15 fps</option>
+                    <option value="30">30 fps</option>
+                </select>
+            </label>
             <label class="parameter-label">Noise level
                 <input id="noiseLevel" type="range" min="0" max="0.6" step="0.01" value="0.2">
+                <span></span>
+            </label>
+            <label class="parameter-label">Thickness scatter
+                <input id="scatterStrength" type="range" min="0" max="1" step="0.01" value="0.45">
+                <span></span>
+            </label>
+            <label class="parameter-label">Collimation
+                <input id="collimation" type="range" min="0" max="0.45" step="0.01" value="0.08">
+                <span></span>
+            </label>
+            <label class="parameter-label">Brightness
+                <input id="imageBrightness" type="range" min="-0.35" max="0.35" step="0.01" value="0">
+                <span></span>
+            </label>
+            <label class="parameter-label">Image contrast
+                <input id="imageContrast" type="range" min="0.5" max="1.8" step="0.01" value="1">
+                <span></span>
+            </label>
+            <label class="parameter-label">Edge enhancement
+                <input id="edgeEnhancement" type="range" min="0" max="2" step="0.05" value="1">
+                <span></span>
             </label>
             <label class="parameter-label">Bone visibility
                 <input id="boneVisibility" type="range" min="0" max="1" step="0.01" value="0.5">
@@ -185,6 +218,6 @@
     }
 }
 </script>
-    <script type="module" src="./src/simulator.js?v=20260615fluoro9"></script>
+    <script type="module" src="./src/simulator.js?v=20260615fluoro20"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -74,6 +74,10 @@
             <label class="parameter-label">Noise level
                 <input id="noiseLevel" type="range" min="0" max="0.6" step="0.01" value="0.2">
             </label>
+            <label class="parameter-label">Bone visibility
+                <input id="boneVisibility" type="range" min="0" max="1" step="0.01" value="0.5">
+                <span></span>
+            </label>
             <label class="parameter-label">Contrast opacity scale
                 <input id="opacityScale" type="range" min="0" max="100" step="1" value="100">
                 <span></span>
@@ -181,6 +185,6 @@
     }
 }
 </script>
-    <script type="module" src="./src/simulator.js?v=20260614physrevert1"></script>
+    <script type="module" src="./src/simulator.js?v=20260615fluoro9"></script>
 </body>
 </html>

--- a/src/shaders/displayShader.js
+++ b/src/shaders/displayShader.js
@@ -18,6 +18,8 @@ uniform sampler2D uTexture;
 uniform sampler2D contrastTexture;
 uniform sampler2D thicknessTexture;
 uniform sampler2D metalTexture;
+uniform sampler2D sheathTexture;
+uniform sampler2D boneTexture;
 uniform vec3 gray;
 uniform bool fluoroscopy;
 uniform float time;
@@ -61,21 +63,81 @@ float metalAt(vec2 uv) {
     return smoothstep(0.025, 0.58, signal);
 }
 
-float bonePathAt(vec2 uv) {
+float sheathAt(vec2 uv) {
+    float signal = sampleSignal(sheathTexture, uv);
+    return smoothstep(0.018, 0.24, signal);
+}
+
+vec3 boneProjectionSampleAt(vec2 uv) {
+    return texture2D(boneTexture, uv).rgb;
+}
+
+float boneProjectionAt(vec2 uv) {
+    vec2 texel = 1.0 / resolution;
+    float center = boneProjectionSampleAt(uv).b * 0.42;
+    float axial = (
+        boneProjectionSampleAt(uv + texel * vec2(1.5, 0.0)).b +
+        boneProjectionSampleAt(uv + texel * vec2(-1.5, 0.0)).b +
+        boneProjectionSampleAt(uv + texel * vec2(0.0, 1.5)).b +
+        boneProjectionSampleAt(uv + texel * vec2(0.0, -1.5)).b
+    ) * 0.10;
+    float diagonal = (
+        boneProjectionSampleAt(uv + texel * vec2(1.2, 1.2)).b +
+        boneProjectionSampleAt(uv + texel * vec2(-1.2, 1.2)).b +
+        boneProjectionSampleAt(uv + texel * vec2(1.2, -1.2)).b +
+        boneProjectionSampleAt(uv + texel * vec2(-1.2, -1.2)).b
+    ) * 0.045;
+    return center + axial + diagonal;
+}
+
+float corticalProjectionAt(vec2 uv) {
+    vec2 texel = 1.0 / resolution;
+    float center = boneProjectionSampleAt(uv).r * 0.50;
+    float axial = (
+        boneProjectionSampleAt(uv + texel * vec2(1.0, 0.0)).r +
+        boneProjectionSampleAt(uv + texel * vec2(-1.0, 0.0)).r +
+        boneProjectionSampleAt(uv + texel * vec2(0.0, 1.0)).r +
+        boneProjectionSampleAt(uv + texel * vec2(0.0, -1.0)).r
+    ) * 0.12;
+    return center + axial;
+}
+
+float thicknessPathAt(vec2 uv) {
     float thickness = texture2D(thicknessTexture, uv).r;
-    return pow(saturate(thickness * 58.0), 0.82);
+    return saturate(thickness * 6.2);
+}
+
+float bonePathAt(vec2 uv) {
+    float thicknessPath = pow(thicknessPathAt(uv), 0.72);
+    float projectedBone = boneProjectionAt(uv);
+    float projectionPath = pow(saturate(projectedBone * 2.5), 0.9) * 0.46;
+    return saturate(thicknessPath * (0.78 + projectionPath * 0.42) + projectionPath * 0.18);
+}
+
+float corticalBoneAt(vec2 uv) {
+    vec2 texel = 1.0 / resolution;
+    float c = thicknessPathAt(uv);
+    float l = thicknessPathAt(uv + texel * vec2(-1.0, 0.0));
+    float r = thicknessPathAt(uv + texel * vec2(1.0, 0.0));
+    float t = thicknessPathAt(uv + texel * vec2(0.0, -1.0));
+    float b = thicknessPathAt(uv + texel * vec2(0.0, 1.0));
+    float thicknessEdge = smoothstep(0.018, 0.14, length(vec2(r - l, b - t)));
+    float entryExitCortex = smoothstep(0.025, 0.22, c) * (0.16 + thicknessEdge * 0.72);
+    float projectedCortex = pow(saturate(corticalProjectionAt(uv) * 3.1), 0.82);
+    return saturate(entryExitCortex + projectedCortex * (0.34 + c * 0.46));
 }
 
 float attenuationAt(vec2 uv) {
     float boneMu = mix(0.18, 2.15, saturate(boneOpacity));
-    float bone = bonePathAt(uv) * boneMu;
+    float bone = (bonePathAt(uv) * 0.72 + corticalBoneAt(uv) * 1.18) * boneMu;
     float iodine = contrastAt(uv) * saturate(contrastOpacity) * 3.25;
     float metal = metalAt(uv) * 5.25;
+    float sheath = sheathAt(uv) * 0.72;
 
     // A small contribution from the accumulated visible frame preserves mild
     // detector lag without letting the old postprocess dominate the image.
     float temporalTrace = smoothstep(0.04, 0.85, sampleSignal(uTexture, uv)) * 0.22;
-    return max(0.0, bone + iodine + metal + temporalTrace);
+    return max(0.0, bone + iodine + metal + sheath + temporalTrace);
 }
 
 float vignetteField(vec2 uv) {

--- a/src/shaders/displayShader.js
+++ b/src/shaders/displayShader.js
@@ -10,12 +10,14 @@ void main() {
 
 export const fragmentShader = `
 // Final display shader.
-// - In fluoroscopy mode: interprets the accumulated buffer as intensity,
-//   adds procedural noise, mixes contrast agent texture, and inverts to
-//   a grayscale X-ray look with adjustable edge emphasis.
+// - In fluoroscopy mode: composes anatomy thickness, iodine contrast, and
+//   metallic devices as radiographic attenuation, then applies detector-style
+//   windowing, edge enhancement, field falloff, and dose-dependent noise.
 // - In wireframe mode: just visualizes the scene with edge-enhanced alpha.
 uniform sampler2D uTexture;
 uniform sampler2D contrastTexture;
+uniform sampler2D thicknessTexture;
+uniform sampler2D metalTexture;
 uniform vec3 gray;
 uniform bool fluoroscopy;
 uniform float time;
@@ -23,11 +25,64 @@ uniform float noiseLevel;
 uniform float boneOpacity;
 uniform vec2 resolution;
 uniform float edgeStrength;
+uniform float contrastOpacity;
+uniform float contrastGain;
 varying vec2 vUv;
 
-// Hash-based noise; time-varying for animated grain.
+float saturate(float value) {
+    return clamp(value, 0.0, 1.0);
+}
+
+float max3(vec3 value) {
+    return max(max(value.r, value.g), value.b);
+}
+
+// Hash-based noise. Animated samples mimic quantum mottle; stable samples are
+// reused for detector fixed-pattern noise.
 float random(vec2 st) {
-    return fract(sin(dot(st.xy, vec2(12.9898, 78.233)) + time) * 43758.5453123);
+    return fract(sin(dot(st.xy, vec2(12.9898, 78.233))) * 43758.5453123);
+}
+
+float animatedNoise(vec2 st, float phase) {
+    return random(st + vec2(phase * 17.37, phase * 5.91));
+}
+
+float sampleSignal(sampler2D source, vec2 uv) {
+    return max3(texture2D(source, uv).rgb);
+}
+
+float contrastAt(vec2 uv) {
+    float signal = sampleSignal(contrastTexture, uv);
+    return saturate(1.0 - exp(-signal * max(0.0, contrastGain) * 1.45));
+}
+
+float metalAt(vec2 uv) {
+    float signal = sampleSignal(metalTexture, uv);
+    return smoothstep(0.025, 0.58, signal);
+}
+
+float bonePathAt(vec2 uv) {
+    float thickness = texture2D(thicknessTexture, uv).r;
+    return pow(saturate(thickness * 58.0), 0.82);
+}
+
+float attenuationAt(vec2 uv) {
+    float boneMu = mix(0.18, 2.15, saturate(boneOpacity));
+    float bone = bonePathAt(uv) * boneMu;
+    float iodine = contrastAt(uv) * saturate(contrastOpacity) * 3.25;
+    float metal = metalAt(uv) * 5.25;
+
+    // A small contribution from the accumulated visible frame preserves mild
+    // detector lag without letting the old postprocess dominate the image.
+    float temporalTrace = smoothstep(0.04, 0.85, sampleSignal(uTexture, uv)) * 0.22;
+    return max(0.0, bone + iodine + metal + temporalTrace);
+}
+
+float vignetteField(vec2 uv) {
+    vec2 centered = uv * 2.0 - 1.0;
+    centered.x *= resolution.x / max(1.0, resolution.y);
+    float radius = length(centered);
+    return 1.0 - 0.22 * smoothstep(0.28, 1.35, radius);
 }
 
 // Simple Sobel-like edge factor based on alpha channel of uTexture.
@@ -48,23 +103,53 @@ float edgeFactor(vec2 uv) {
 }
 void main() {
     vec4 tex = texture2D(uTexture, vUv);
-    float edge = edgeFactor(vUv) * edgeStrength;
     if (fluoroscopy) {
-        // Convert accumulated intensity to inverted grayscale appearance.
-        float intensity = tex.r * boneOpacity;
-        float noise = random(vUv * 100.0) - 0.5;
-        intensity += noise * noiseLevel;
-        intensity = clamp(intensity, 0.0, 1.0);
-        // Contrast agent (additive brightening) sampled separately and
-        // mixed into the image.
-        vec4 cSample = texture2D(contrastTexture, vUv);
-        float contrastSignal = max(max(cSample.r, cSample.g), cSample.b);
-        float contrast = clamp(contrastSignal * 3.35, 0.0, 1.0);
-        vec3 color = gray * (1.0 - intensity);
-        float alpha = clamp(1.0 + edge, 0.0, 1.0);
-        gl_FragColor = vec4(mix(color, vec3(0.0), contrast), alpha);
+        vec2 texel = 1.0 / resolution;
+        float centerAttenuation = attenuationAt(vUv);
+        float neighborAttenuation = (
+            attenuationAt(vUv + texel * vec2(1.0, 0.0)) +
+            attenuationAt(vUv + texel * vec2(-1.0, 0.0)) +
+            attenuationAt(vUv + texel * vec2(0.0, 1.0)) +
+            attenuationAt(vUv + texel * vec2(0.0, -1.0))
+        ) * 0.25;
+
+        // C-arm images are usually edge-enhanced after acquisition. Sharpen
+        // attenuation before transmission so radiopaque borders get the expected
+        // dark/bright overshoot instead of an alpha-only outline.
+        float sharpenedAttenuation = max(
+            0.0,
+            centerAttenuation + (centerAttenuation - neighborAttenuation) * edgeStrength * 0.34
+        );
+
+        float transmission = exp(-sharpenedAttenuation);
+        float scatterFog = saturate(centerAttenuation * 0.06);
+        transmission = mix(transmission, 0.62, scatterFog);
+
+        // Detector window/level with a soft shoulder. This keeps the air field
+        // from becoming pure white and gives dense contrast a real black floor.
+        float luma = pow(saturate(transmission), 0.72);
+        luma = smoothstep(0.035, 0.985, luma);
+        luma = mix(0.08, 0.88, luma);
+
+        float field = vignetteField(vUv);
+        float fixedPattern = (random(floor(vUv * resolution / 7.0)) - 0.5) * 0.022;
+        float columnPattern = (random(vec2(floor(vUv.x * resolution.x / 3.0), 19.0)) - 0.5) * 0.012;
+        float gridPattern =
+            sin(vUv.x * resolution.x * 0.86) * 0.0035 +
+            sin(vUv.y * resolution.y * 0.42) * 0.0025;
+        float mottle = (animatedNoise(vUv * resolution, time * 23.0) - 0.5)
+            * noiseLevel
+            * (0.15 + 0.32 * sqrt(max(luma, 0.0)));
+
+        luma = saturate(luma * field + fixedPattern + columnPattern + gridPattern + mottle);
+
+        // Phosphor/detector response is slightly warm-neutral, not mathematically
+        // flat grayscale. Keep it subtle so it still reads as fluoroscopy.
+        vec3 detectorTint = vec3(0.965, 0.982, 1.0);
+        gl_FragColor = vec4(gray * detectorTint * luma, 1.0);
     } else {
         // Debug mode: keep original color, use edge to boost alpha.
+        float edge = edgeFactor(vUv) * edgeStrength;
         float alpha = clamp(tex.a + edge, 0.0, 1.0);
         gl_FragColor = vec4(tex.rgb, alpha);
     }

--- a/src/shaders/displayShader.js
+++ b/src/shaders/displayShader.js
@@ -24,6 +24,13 @@ uniform vec3 gray;
 uniform bool fluoroscopy;
 uniform float time;
 uniform float noiseLevel;
+uniform float imageBrightness;
+uniform float imageContrast;
+uniform bool autoExposureEnabled;
+uniform float autoExposureLevel;
+uniform float pulseRate;
+uniform float scatterStrength;
+uniform float collimation;
 uniform float boneOpacity;
 uniform vec2 resolution;
 uniform float edgeStrength;
@@ -65,7 +72,7 @@ float metalAt(vec2 uv) {
 
 float sheathAt(vec2 uv) {
     float signal = sampleSignal(sheathTexture, uv);
-    return smoothstep(0.018, 0.24, signal);
+    return smoothstep(0.03, 0.32, signal);
 }
 
 vec3 boneProjectionSampleAt(vec2 uv) {
@@ -92,14 +99,32 @@ float boneProjectionAt(vec2 uv) {
 
 float corticalProjectionAt(vec2 uv) {
     vec2 texel = 1.0 / resolution;
-    float center = boneProjectionSampleAt(uv).r * 0.50;
-    float axial = (
-        boneProjectionSampleAt(uv + texel * vec2(1.0, 0.0)).r +
-        boneProjectionSampleAt(uv + texel * vec2(-1.0, 0.0)).r +
-        boneProjectionSampleAt(uv + texel * vec2(0.0, 1.0)).r +
-        boneProjectionSampleAt(uv + texel * vec2(0.0, -1.0)).r
-    ) * 0.12;
-    return center + axial;
+    float center = boneProjectionSampleAt(uv).r * 0.34;
+    float nearAxial = (
+        boneProjectionSampleAt(uv + texel * vec2(1.45, 0.0)).r +
+        boneProjectionSampleAt(uv + texel * vec2(-1.45, 0.0)).r +
+        boneProjectionSampleAt(uv + texel * vec2(0.0, 1.45)).r +
+        boneProjectionSampleAt(uv + texel * vec2(0.0, -1.45)).r
+    ) * 0.075;
+    float diagonal = (
+        boneProjectionSampleAt(uv + texel * vec2(1.75, 1.75)).r +
+        boneProjectionSampleAt(uv + texel * vec2(-1.75, 1.75)).r +
+        boneProjectionSampleAt(uv + texel * vec2(1.75, -1.75)).r +
+        boneProjectionSampleAt(uv + texel * vec2(-1.75, -1.75)).r
+    ) * 0.04;
+    float wideAxial = (
+        boneProjectionSampleAt(uv + texel * vec2(3.25, 0.0)).r +
+        boneProjectionSampleAt(uv + texel * vec2(-3.25, 0.0)).r +
+        boneProjectionSampleAt(uv + texel * vec2(0.0, 3.25)).r +
+        boneProjectionSampleAt(uv + texel * vec2(0.0, -3.25)).r
+    ) * 0.03;
+    float wideDiagonal = (
+        boneProjectionSampleAt(uv + texel * vec2(2.75, 2.75)).r +
+        boneProjectionSampleAt(uv + texel * vec2(-2.75, 2.75)).r +
+        boneProjectionSampleAt(uv + texel * vec2(2.75, -2.75)).r +
+        boneProjectionSampleAt(uv + texel * vec2(-2.75, -2.75)).r
+    ) * 0.018;
+    return center + nearAxial + diagonal + wideAxial + wideDiagonal;
 }
 
 float thicknessPathAt(vec2 uv) {
@@ -121,18 +146,18 @@ float corticalBoneAt(vec2 uv) {
     float r = thicknessPathAt(uv + texel * vec2(1.0, 0.0));
     float t = thicknessPathAt(uv + texel * vec2(0.0, -1.0));
     float b = thicknessPathAt(uv + texel * vec2(0.0, 1.0));
-    float thicknessEdge = smoothstep(0.018, 0.14, length(vec2(r - l, b - t)));
-    float entryExitCortex = smoothstep(0.025, 0.22, c) * (0.16 + thicknessEdge * 0.72);
-    float projectedCortex = pow(saturate(corticalProjectionAt(uv) * 3.1), 0.82);
-    return saturate(entryExitCortex + projectedCortex * (0.34 + c * 0.46));
+    float thicknessEdge = smoothstep(0.014, 0.19, length(vec2(r - l, b - t)));
+    float entryExitCortex = smoothstep(0.026, 0.31, c) * (0.11 + thicknessEdge * 0.4);
+    float projectedCortex = pow(saturate(corticalProjectionAt(uv) * 2.65), 0.78);
+    return saturate(entryExitCortex + projectedCortex * (0.27 + c * 0.38));
 }
 
 float attenuationAt(vec2 uv) {
     float boneMu = mix(0.18, 2.15, saturate(boneOpacity));
-    float bone = (bonePathAt(uv) * 0.72 + corticalBoneAt(uv) * 1.18) * boneMu;
+    float bone = (bonePathAt(uv) * 0.74 + corticalBoneAt(uv) * 0.82) * boneMu;
     float iodine = contrastAt(uv) * saturate(contrastOpacity) * 3.25;
     float metal = metalAt(uv) * 5.25;
-    float sheath = sheathAt(uv) * 0.72;
+    float sheath = sheathAt(uv) * 0.42;
 
     // A small contribution from the accumulated visible frame preserves mild
     // detector lag without letting the old postprocess dominate the image.
@@ -145,6 +170,33 @@ float vignetteField(vec2 uv) {
     centered.x *= resolution.x / max(1.0, resolution.y);
     float radius = length(centered);
     return 1.0 - 0.22 * smoothstep(0.28, 1.35, radius);
+}
+
+float patientBodyField(vec2 uv) {
+    vec2 centered = uv * 2.0 - 1.0;
+    centered.x *= resolution.x / max(1.0, resolution.y);
+    float pelvis = 1.0 - smoothstep(0.42, 1.18, length(centered * vec2(0.72, 1.05)));
+    float trunk = 1.0 - smoothstep(0.35, 1.08, length((centered - vec2(0.0, -0.18)) * vec2(0.62, 1.35)));
+    return saturate(max(pelvis, trunk * 0.72));
+}
+
+float scatterFieldAt(vec2 uv, float attenuation) {
+    float tissuePath = patientBodyField(uv);
+    float projectedPath = saturate(thicknessPathAt(uv) * 0.55 + bonePathAt(uv) * 0.26 + tissuePath * 0.22);
+    return saturate(scatterStrength * (projectedPath * 0.72 + attenuation * 0.08));
+}
+
+float collimatorMask(vec2 uv) {
+    vec2 centered = uv * 2.0 - 1.0;
+    float crop = saturate(collimation);
+    vec2 halfSize = vec2(1.0 - crop * 1.35, 1.0 - crop * 1.18);
+    float softness = 0.022 + crop * 0.055;
+    float maskX = 1.0 - smoothstep(halfSize.x, halfSize.x + softness, abs(centered.x));
+    float maskY = 1.0 - smoothstep(halfSize.y, halfSize.y + softness, abs(centered.y));
+    vec2 roundCoord = centered;
+    roundCoord.x *= resolution.x / max(1.0, resolution.y);
+    float roundMask = 1.0 - smoothstep(1.28 - crop * 0.62, 1.34 - crop * 0.62, length(roundCoord));
+    return saturate(maskX * maskY * roundMask);
 }
 
 // Simple Sobel-like edge factor based on alpha channel of uTexture.
@@ -168,6 +220,8 @@ void main() {
     if (fluoroscopy) {
         vec2 texel = 1.0 / resolution;
         float centerAttenuation = attenuationAt(vUv);
+        float localScatter = scatterFieldAt(vUv, centerAttenuation);
+        float exposureLift = autoExposureEnabled ? autoExposureLevel : 0.0;
         float neighborAttenuation = (
             attenuationAt(vUv + texel * vec2(1.0, 0.0)) +
             attenuationAt(vUv + texel * vec2(-1.0, 0.0)) +
@@ -178,14 +232,15 @@ void main() {
         // C-arm images are usually edge-enhanced after acquisition. Sharpen
         // attenuation before transmission so radiopaque borders get the expected
         // dark/bright overshoot instead of an alpha-only outline.
+        float scatterSoftenedEdge = mix(0.34, 0.16, localScatter);
         float sharpenedAttenuation = max(
             0.0,
-            centerAttenuation + (centerAttenuation - neighborAttenuation) * edgeStrength * 0.34
+            centerAttenuation + (centerAttenuation - neighborAttenuation) * edgeStrength * scatterSoftenedEdge
         );
 
         float transmission = exp(-sharpenedAttenuation);
-        float scatterFog = saturate(centerAttenuation * 0.06);
-        transmission = mix(transmission, 0.62, scatterFog);
+        float scatterFog = saturate(centerAttenuation * 0.045 + localScatter * 0.42);
+        transmission = mix(transmission, 0.60 + exposureLift * 0.18, scatterFog);
 
         // Detector window/level with a soft shoulder. This keeps the air field
         // from becoming pure white and gives dense contrast a real black floor.
@@ -199,11 +254,19 @@ void main() {
         float gridPattern =
             sin(vUv.x * resolution.x * 0.86) * 0.0035 +
             sin(vUv.y * resolution.y * 0.42) * 0.0025;
-        float mottle = (animatedNoise(vUv * resolution, time * 23.0) - 0.5)
+        float doseNoiseScale = sqrt(30.0 / clamp(pulseRate, 7.5, 30.0));
+        float pulseIndex = floor(time * max(1.0, pulseRate));
+        float pulseJitter = (random(vec2(pulseIndex, 37.0)) - 0.5) * 0.012 * doseNoiseScale;
+        float mottle = (animatedNoise(vUv * resolution, pulseIndex * 0.73) - 0.5)
             * noiseLevel
+            * doseNoiseScale
             * (0.15 + 0.32 * sqrt(max(luma, 0.0)));
 
-        luma = saturate(luma * field + fixedPattern + columnPattern + gridPattern + mottle);
+        luma = saturate(luma * field + fixedPattern + columnPattern + gridPattern + mottle + pulseJitter);
+        luma = mix(luma, 0.56 + (luma - 0.56) * 0.54, localScatter * 0.46);
+        luma = saturate(luma + exposureLift);
+        luma = saturate((luma - 0.5) * max(0.0, imageContrast) + 0.5 + imageBrightness);
+        luma = mix(0.018, luma, collimatorMask(vUv));
 
         // Phosphor/detector response is slightly warm-neutral, not mathematically
         // flat grayscale. Keep it subtle so it still reads as fluoroscopy.

--- a/src/shaders/thicknessShader.js
+++ b/src/shaders/thicknessShader.js
@@ -10,18 +10,17 @@ void main() {
 
 export const fragmentShader = `
 // Thickness estimation shader.
-// Uses front and back depth renders of opaque geometry to estimate
-// per-pixel thickness along the view ray: thickness = back - front.
-// This can be used to approximate X-ray attenuation or soft shading.
+// Uses front and back depth renders to estimate per-pixel path length through
+// the rendered anatomy. MeshDepthMaterial depth direction can vary with the
+// packing path, so the signed front/back delta is treated as a magnitude here.
 uniform sampler2D frontDepth;
 uniform sampler2D backDepth;
 varying vec2 vUv;
 void main() {
     float front = texture2D(frontDepth, vUv).r;
     float back = texture2D(backDepth, vUv).r;
-    float thick = max(back - front, 0.0);
+    float thick = abs(back - front);
 
     gl_FragColor = vec4(vec3(thick), 1.0);
 }
 `;
-

--- a/src/shaders/thicknessShader.js
+++ b/src/shaders/thicknessShader.js
@@ -10,17 +10,17 @@ void main() {
 
 export const fragmentShader = `
 // Thickness estimation shader.
-// Uses front and back depth renders to estimate per-pixel path length through
-// the rendered anatomy. MeshDepthMaterial depth direction can vary with the
-// packing path, so the signed front/back delta is treated as a magnitude here.
+// Front/back textures store linear camera-space depth normalized to camera far.
+// Their difference is an approximation of X-ray path length through bone for
+// the current C-arm projection.
 uniform sampler2D frontDepth;
 uniform sampler2D backDepth;
 varying vec2 vUv;
 void main() {
     float front = texture2D(frontDepth, vUv).r;
     float back = texture2D(backDepth, vUv).r;
-    float thick = abs(back - front);
+    float thick = max(back - front, 0.0);
 
-    gl_FragColor = vec4(vec3(thick), 1.0);
+    gl_FragColor = vec4(vec3(clamp(thick, 0.0, 1.0)), 1.0);
 }
 `;

--- a/src/simulator.js
+++ b/src/simulator.js
@@ -2,14 +2,14 @@
 import * as THREE from 'three';
 import { ElasticRod } from './physics/elasticRod.js?v=20260614physrevert1';
 import { generateVessel } from './vesselGeometry.js?v=20260614guidewirestable1';
-import { initUI } from './ui/ui.js?v=20260615fluoro1';
+import { initUI } from './ui/ui.js?v=20260615fluoro8';
 import { createBoneModel } from './boneModel.js';
 import { FlowContrastAgent, updateFlowContrastMesh } from './contrastFlowAgent.js?v=20260614guidewirestable1';
 import { PigtailCatheter } from './pigtailCatheter.js?v=20260614guidewirestable1';
 import { createAortaModel } from './aortaModel.js?v=20260614guidewirestable1';
 import { vertexShader as blendVS, fragmentShader as blendFS } from './shaders/blendShader.js';
 import { vertexShader as thicknessVS, fragmentShader as thicknessFS } from './shaders/thicknessShader.js';
-import { vertexShader as displayVS, fragmentShader as displayFS } from './shaders/displayShader.js?v=20260615fluoro1';
+import { vertexShader as displayVS, fragmentShader as displayFS } from './shaders/displayShader.js?v=20260615fluoro9';
 
 const LUMEN_DEBUG_COLOR = 0x29ffd4;
 const WALL_CONTACT_COLOR = 0xffd24a;
@@ -17,6 +17,8 @@ const WALL_BREACH_COLOR = 0xff3355;
 const CONTACT_MARKER_LIMIT = 420;
 const CONTACT_MARKER_UPDATE_INTERVAL = 1 / 18;
 const PIGTAIL_MESH_UPDATE_INTERVAL = 1 / 30;
+const XRAY_CAMERA_NEAR = 0.1;
+const XRAY_CAMERA_FAR = 1000;
 
 // WebGL renderer attached to the fullscreen canvas
 const canvas = document.getElementById('sim');
@@ -34,6 +36,8 @@ const contrastScene = new THREE.Scene();
 const offscreenTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
 const contrastTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
 const metalTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
+const sheathTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
+const boneTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
 const accumulateTarget1 = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
 const accumulateTarget2 = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
 const frontDepthTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
@@ -58,14 +62,38 @@ const blendQuad = new THREE.Mesh(quadGeometry, blendMaterial);
 const blendScene = new THREE.Scene();
 blendScene.add(blendQuad);
 
-// Depth-only materials used to compute front/back depth for thickness
-const depthMaterialFront = new THREE.MeshDepthMaterial({ side: THREE.FrontSide });
-const depthMaterialBack = new THREE.MeshDepthMaterial({
-    side: THREE.BackSide,
+function createLinearDepthMaterial(side) {
+    return new THREE.ShaderMaterial({
+        side,
+        depthTest: true,
+        depthWrite: true,
+        uniforms: {
+            cameraNear: { value: XRAY_CAMERA_NEAR },
+            cameraFar: { value: XRAY_CAMERA_FAR }
+        },
+        vertexShader: `
+            varying float vViewDepth;
+            void main() {
+                vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+                vViewDepth = -mvPosition.z;
+                gl_Position = projectionMatrix * mvPosition;
+            }
+        `,
+        fragmentShader: `
+            uniform float cameraNear;
+            uniform float cameraFar;
+            varying float vViewDepth;
+            void main() {
+                float depth = clamp((vViewDepth - cameraNear) / max(1.0, cameraFar - cameraNear), 0.0, 1.0);
+                gl_FragColor = vec4(vec3(depth), 1.0);
+            }
+        `
+    });
+}
 
-    depthTest: false
-
-});
+// Depth-only materials used to compute front/back ray length through bone.
+const depthMaterialFront = createLinearDepthMaterial(THREE.FrontSide);
+const depthMaterialBack = createLinearDepthMaterial(THREE.BackSide);
 const thicknessMaterial = new THREE.ShaderMaterial({
     uniforms: {
         frontDepth: { value: frontDepthTarget.texture },
@@ -77,6 +105,70 @@ const thicknessMaterial = new THREE.ShaderMaterial({
 const thicknessQuad = new THREE.Mesh(quadGeometry, thicknessMaterial);
 const thicknessScene = new THREE.Scene();
 thicknessScene.add(thicknessQuad);
+const boneProjectionMaterial = new THREE.ShaderMaterial({
+    transparent: true,
+    blending: THREE.AdditiveBlending,
+    side: THREE.DoubleSide,
+    depthTest: true,
+    depthWrite: false,
+    vertexShader: `
+        varying vec3 vViewNormal;
+        varying vec3 vWorldPosition;
+        void main() {
+            vViewNormal = normalize(normalMatrix * normal);
+            vec4 worldPosition = modelMatrix * vec4(position, 1.0);
+            vWorldPosition = worldPosition.xyz;
+            gl_Position = projectionMatrix * viewMatrix * worldPosition;
+        }
+    `,
+    fragmentShader: `
+        varying vec3 vViewNormal;
+        varying vec3 vWorldPosition;
+
+        float hash(vec3 p) {
+            return fract(sin(dot(p, vec3(17.13, 47.71, 91.37))) * 43758.5453);
+        }
+
+        float valueNoise(vec3 p) {
+            vec3 i = floor(p);
+            vec3 f = fract(p);
+            f = f * f * (3.0 - 2.0 * f);
+            float n000 = hash(i + vec3(0.0, 0.0, 0.0));
+            float n100 = hash(i + vec3(1.0, 0.0, 0.0));
+            float n010 = hash(i + vec3(0.0, 1.0, 0.0));
+            float n110 = hash(i + vec3(1.0, 1.0, 0.0));
+            float n001 = hash(i + vec3(0.0, 0.0, 1.0));
+            float n101 = hash(i + vec3(1.0, 0.0, 1.0));
+            float n011 = hash(i + vec3(0.0, 1.0, 1.0));
+            float n111 = hash(i + vec3(1.0, 1.0, 1.0));
+            float nx00 = mix(n000, n100, f.x);
+            float nx10 = mix(n010, n110, f.x);
+            float nx01 = mix(n001, n101, f.x);
+            float nx11 = mix(n011, n111, f.x);
+            float nxy0 = mix(nx00, nx10, f.y);
+            float nxy1 = mix(nx01, nx11, f.y);
+            return mix(nxy0, nxy1, f.z);
+        }
+
+        void main() {
+            float facing = abs(normalize(vViewNormal).z);
+            float cortex = pow(1.0 - facing, 2.35);
+            float broadDensity = pow(facing, 0.55) * 0.035;
+
+            vec3 p = vWorldPosition * 0.035;
+            float coarse = valueNoise(p);
+            float fine = valueNoise(p * 2.8 + vec3(4.0, 11.0, 2.0));
+            float trabeculae = smoothstep(0.38, 0.86, coarse * 0.68 + fine * 0.32);
+            float striation = 0.5 + 0.5 * sin(vWorldPosition.y * 0.18 + valueNoise(p * 0.7) * 5.0);
+
+            float corticalSignal = cortex * 0.24 + broadDensity * 0.08;
+            float trabecularSignal = broadDensity * 0.72 + trabeculae * striation * 0.06;
+            float totalSignal = corticalSignal + trabecularSignal * 0.62;
+
+            gl_FragColor = vec4(corticalSignal, trabecularSignal, totalSignal, 1.0);
+        }
+    `
+});
 
 const displayMaterial = new THREE.ShaderMaterial({
     uniforms: {
@@ -84,11 +176,12 @@ const displayMaterial = new THREE.ShaderMaterial({
         contrastTexture: { value: contrastTarget.texture },
         thicknessTexture: { value: thicknessTarget.texture },
         metalTexture: { value: metalTarget.texture },
+        sheathTexture: { value: sheathTarget.texture },
+        boneTexture: { value: boneTarget.texture },
         gray: { value: new THREE.Color(0xEBEBEB) },
         fluoroscopy: { value: false },
         time: { value: 0 },
         noiseLevel: { value: 0.05 },
-        // Lower default bone opacity so bones appear less prominent
         boneOpacity: { value: 0.5 },
         resolution: { value: new THREE.Vector2(window.innerWidth, window.innerHeight) },
         edgeStrength: { value: 1.0 },
@@ -105,7 +198,7 @@ displayScene.add(displayQuad);
 
 // C-arm configuration: camera acts as X-ray source; detector is simulated in shaders
 const cameraRadius = 350;
-const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, 0.1, 1000);
+const camera = new THREE.PerspectiveCamera(45, window.innerWidth / window.innerHeight, XRAY_CAMERA_NEAR, XRAY_CAMERA_FAR);
 camera.position.set(0, 80, cameraRadius);
 scene.add(camera);
 
@@ -151,7 +244,7 @@ function createSheathFluoroMesh(sheath) {
         color: 0xffffff,
         side: THREE.DoubleSide,
         transparent: true,
-        opacity: 0.16,
+        opacity: 0.10,
         depthTest: false,
         depthWrite: false
     });
@@ -1216,9 +1309,9 @@ function animate(time) {
     if (fluoroscopy) {
         // Fluoroscopy path:
         // 1) render front/back depth for thickness
-        // 2) render contrast to its target with transparent clear
+        // 2) render stable bone/contrast/metal masks for attenuation
         // 3) render scene to offscreen, accumulate with decay
-        // 4) display accumulated + contrast via display shader
+        // 4) display attenuated fluoroscopy image via display shader
         const hidden = [];
         for (const child of scene.children) {
             if (child !== skeletonModel && !child.isCamera) {
@@ -1243,6 +1336,13 @@ function animate(time) {
         renderer.render(thicknessScene, postCamera);
         renderer.setRenderTarget(null);
 
+        renderer.setRenderTarget(boneTarget);
+        renderer.clear();
+        scene.overrideMaterial = boneProjectionMaterial;
+        renderOnlySceneObjects(scene, camera, [skeletonModel]);
+        scene.overrideMaterial = null;
+        renderer.setRenderTarget(null);
+
         renderer.setRenderTarget(contrastTarget);
         withTransparentClear(renderer, () => {
             renderer.clear();
@@ -1254,9 +1354,14 @@ function animate(time) {
             renderer.clear();
             renderOnlySceneObjects(scene, camera, [
                 wireMesh,
-                pigtailCatheter.mesh,
-                sheathFluoroMesh
+                pigtailCatheter.mesh
             ]);
+        });
+
+        renderer.setRenderTarget(sheathTarget);
+        withTransparentClear(renderer, () => {
+            renderer.clear();
+            renderOnlySceneObjects(scene, camera, [sheathFluoroMesh]);
         });
 
         renderer.setRenderTarget(offscreenTarget);
@@ -1279,6 +1384,8 @@ function animate(time) {
         displayMaterial.uniforms.contrastTexture.value = contrastTarget.texture;
         displayMaterial.uniforms.thicknessTexture.value = thicknessTarget.texture;
         displayMaterial.uniforms.metalTexture.value = metalTarget.texture;
+        displayMaterial.uniforms.sheathTexture.value = sheathTarget.texture;
+        displayMaterial.uniforms.boneTexture.value = boneTarget.texture;
         displayMaterial.uniforms.time.value = time * 0.001;
         renderer.render(displayScene, postCamera);
 
@@ -1307,6 +1414,8 @@ window.addEventListener('resize', () => {
     offscreenTarget.setSize(w, h);
     contrastTarget.setSize(w, h);
     metalTarget.setSize(w, h);
+    sheathTarget.setSize(w, h);
+    boneTarget.setSize(w, h);
     accumulateTarget1.setSize(w, h);
     accumulateTarget2.setSize(w, h);
     frontDepthTarget.setSize(w, h);

--- a/src/simulator.js
+++ b/src/simulator.js
@@ -2,14 +2,14 @@
 import * as THREE from 'three';
 import { ElasticRod } from './physics/elasticRod.js?v=20260614physrevert1';
 import { generateVessel } from './vesselGeometry.js?v=20260614guidewirestable1';
-import { initUI } from './ui/ui.js?v=20260615fluoro8';
+import { initUI } from './ui/ui.js?v=20260615fluoro18';
 import { createBoneModel } from './boneModel.js';
 import { FlowContrastAgent, updateFlowContrastMesh } from './contrastFlowAgent.js?v=20260614guidewirestable1';
 import { PigtailCatheter } from './pigtailCatheter.js?v=20260614guidewirestable1';
 import { createAortaModel } from './aortaModel.js?v=20260614guidewirestable1';
 import { vertexShader as blendVS, fragmentShader as blendFS } from './shaders/blendShader.js';
 import { vertexShader as thicknessVS, fragmentShader as thicknessFS } from './shaders/thicknessShader.js';
-import { vertexShader as displayVS, fragmentShader as displayFS } from './shaders/displayShader.js?v=20260615fluoro9';
+import { vertexShader as displayVS, fragmentShader as displayFS } from './shaders/displayShader.js?v=20260615fluoro19';
 
 const LUMEN_DEBUG_COLOR = 0x29ffd4;
 const WALL_CONTACT_COLOR = 0xffd24a;
@@ -152,17 +152,17 @@ const boneProjectionMaterial = new THREE.ShaderMaterial({
 
         void main() {
             float facing = abs(normalize(vViewNormal).z);
-            float cortex = pow(1.0 - facing, 2.35);
+            float cortex = pow(1.0 - facing, 1.16);
             float broadDensity = pow(facing, 0.55) * 0.035;
 
             vec3 p = vWorldPosition * 0.035;
             float coarse = valueNoise(p);
             float fine = valueNoise(p * 2.8 + vec3(4.0, 11.0, 2.0));
-            float trabeculae = smoothstep(0.38, 0.86, coarse * 0.68 + fine * 0.32);
-            float striation = 0.5 + 0.5 * sin(vWorldPosition.y * 0.18 + valueNoise(p * 0.7) * 5.0);
+            float trabeculae = smoothstep(0.42, 0.92, coarse * 0.62 + fine * 0.38);
+            float marrowMottle = mix(0.72, 1.08, valueNoise(p * 1.35 + vec3(2.0, 7.0, 13.0)));
 
-            float corticalSignal = cortex * 0.24 + broadDensity * 0.08;
-            float trabecularSignal = broadDensity * 0.72 + trabeculae * striation * 0.06;
+            float corticalSignal = cortex * 0.18 + broadDensity * 0.06;
+            float trabecularSignal = broadDensity * 0.66 + trabeculae * marrowMottle * 0.032;
             float totalSignal = corticalSignal + trabecularSignal * 0.62;
 
             gl_FragColor = vec4(corticalSignal, trabecularSignal, totalSignal, 1.0);
@@ -182,6 +182,13 @@ const displayMaterial = new THREE.ShaderMaterial({
         fluoroscopy: { value: false },
         time: { value: 0 },
         noiseLevel: { value: 0.05 },
+        imageBrightness: { value: 0.0 },
+        imageContrast: { value: 1.0 },
+        autoExposureEnabled: { value: true },
+        autoExposureLevel: { value: 0.0 },
+        pulseRate: { value: 15.0 },
+        scatterStrength: { value: 0.45 },
+        collimation: { value: 0.08 },
         boneOpacity: { value: 0.5 },
         resolution: { value: new THREE.Vector2(window.innerWidth, window.innerHeight) },
         edgeStrength: { value: 1.0 },
@@ -244,7 +251,7 @@ function createSheathFluoroMesh(sheath) {
         color: 0xffffff,
         side: THREE.DoubleSide,
         transparent: true,
-        opacity: 0.10,
+        opacity: 0.065,
         depthTest: false,
         depthWrite: false
     });
@@ -1166,8 +1173,50 @@ function updateGuidewireResistance(advance, commandedDelta, tipBefore) {
 
 const fixedDt = 1 / 60;
 let lastRenderTime = performance.now();
+let lastFluoroPulseTime = -Infinity;
+let autoExposureLevel = 0;
+const autoExposureBeamDirection = new THREE.Vector3();
 let contactMarkerAccumulator = CONTACT_MARKER_UPDATE_INTERVAL;
 let pigtailMeshAccumulator = PIGTAIL_MESH_UPDATE_INTERVAL;
+
+function updateAutoExposure(dt) {
+    const uniforms = displayMaterial.uniforms;
+    const response = Math.min(1, Math.max(0, dt) * 1.35);
+    if (!uniforms.autoExposureEnabled.value) {
+        autoExposureLevel += (0 - autoExposureLevel) * Math.min(1, response * 1.6);
+        uniforms.autoExposureLevel.value = autoExposureLevel;
+        return;
+    }
+
+    camera.getWorldDirection(autoExposureBeamDirection);
+    const lateralPath = Math.abs(autoExposureBeamDirection.x);
+    const cranialPath = Math.abs(autoExposureBeamDirection.y);
+    const obliquityLoad = Math.max(0, lateralPath - 0.1);
+    const collimationAmount = THREE.MathUtils.clamp((uniforms.collimation.value || 0) / 0.45, 0, 1);
+    const collimationExposureRelief = 1 - collimationAmount * 0.34;
+    const uncollimatedTarget = 0.012 + obliquityLoad * 0.15 + cranialPath * 0.035;
+    const target = THREE.MathUtils.clamp(
+        uncollimatedTarget * collimationExposureRelief - collimationAmount * 0.006,
+        -0.03,
+        0.18
+    );
+    autoExposureLevel += (target - autoExposureLevel) * response;
+    uniforms.autoExposureLevel.value = autoExposureLevel;
+}
+
+function updateXrayTechniqueReadout() {
+    const uniforms = displayMaterial.uniforms;
+    const pulseRate = THREE.MathUtils.clamp(uniforms.pulseRate.value || 15, 7.5, 30);
+    const exposureRatio = uniforms.autoExposureEnabled.value
+        ? THREE.MathUtils.clamp(autoExposureLevel / 0.18, 0, 1)
+        : 0.25;
+    const kV = 70 + exposureRatio * 28;
+    const pulseLoad = Math.pow(pulseRate / 15, 0.72);
+    const collimationAmount = THREE.MathUtils.clamp((uniforms.collimation.value || 0) / 0.45, 0, 1);
+    const collimationDoseLoad = 1 - collimationAmount * 0.42;
+    const mA = (2.4 + exposureRatio * 7.2) * pulseLoad * collimationDoseLoad;
+    ui.updateXrayTechnique(kV, mA);
+}
 
 function stepSimulation() {
     // Advance input, integrate rod physics, collisions, and update medical monitors
@@ -1307,6 +1356,20 @@ function animate(time) {
     ui.setInjectButtonDisabled(contrastActive);
     ui.setStopInjectionDisabled(!injecting);
     if (fluoroscopy) {
+        updateAutoExposure(dt);
+        updateXrayTechniqueReadout();
+        const pulseRate = Math.max(1, displayMaterial.uniforms.pulseRate.value || 15);
+        const pulseInterval = 1000 / pulseRate;
+        const shouldAcquireFluoroFrame = time - lastFluoroPulseTime >= pulseInterval;
+        if (!shouldAcquireFluoroFrame) {
+            renderer.setRenderTarget(null);
+            renderer.render(displayScene, postCamera);
+            ui.updatePerfStats(dt);
+            requestAnimationFrame(animate);
+            return;
+        }
+        lastFluoroPulseTime = time;
+
         // Fluoroscopy path:
         // 1) render front/back depth for thickness
         // 2) render stable bone/contrast/metal masks for attenuation
@@ -1394,6 +1457,8 @@ function animate(time) {
         previousTarget = currentTarget;
         currentTarget = temp;
     } else {
+        lastFluoroPulseTime = -Infinity;
+        updateXrayTechniqueReadout();
         renderer.setRenderTarget(null);
         renderer.render(scene, camera);
     }

--- a/src/simulator.js
+++ b/src/simulator.js
@@ -2,14 +2,14 @@
 import * as THREE from 'three';
 import { ElasticRod } from './physics/elasticRod.js?v=20260614physrevert1';
 import { generateVessel } from './vesselGeometry.js?v=20260614guidewirestable1';
-import { initUI } from './ui/ui.js?v=20260614debug1';
+import { initUI } from './ui/ui.js?v=20260615fluoro1';
 import { createBoneModel } from './boneModel.js';
 import { FlowContrastAgent, updateFlowContrastMesh } from './contrastFlowAgent.js?v=20260614guidewirestable1';
 import { PigtailCatheter } from './pigtailCatheter.js?v=20260614guidewirestable1';
 import { createAortaModel } from './aortaModel.js?v=20260614guidewirestable1';
 import { vertexShader as blendVS, fragmentShader as blendFS } from './shaders/blendShader.js';
 import { vertexShader as thicknessVS, fragmentShader as thicknessFS } from './shaders/thicknessShader.js';
-import { vertexShader as displayVS, fragmentShader as displayFS } from './shaders/displayShader.js?v=20260614debug1';
+import { vertexShader as displayVS, fragmentShader as displayFS } from './shaders/displayShader.js?v=20260615fluoro1';
 
 const LUMEN_DEBUG_COLOR = 0x29ffd4;
 const WALL_CONTACT_COLOR = 0xffd24a;
@@ -33,6 +33,7 @@ const contrastScene = new THREE.Scene();
 // Offscreen render targets used by various post-processing passes
 const offscreenTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
 const contrastTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
+const metalTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
 const accumulateTarget1 = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
 const accumulateTarget2 = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
 const frontDepthTarget = new THREE.WebGLRenderTarget(window.innerWidth, window.innerHeight);
@@ -81,6 +82,8 @@ const displayMaterial = new THREE.ShaderMaterial({
     uniforms: {
         uTexture: { value: previousTarget.texture },
         contrastTexture: { value: contrastTarget.texture },
+        thicknessTexture: { value: thicknessTarget.texture },
+        metalTexture: { value: metalTarget.texture },
         gray: { value: new THREE.Color(0xEBEBEB) },
         fluoroscopy: { value: false },
         time: { value: 0 },
@@ -88,7 +91,9 @@ const displayMaterial = new THREE.ShaderMaterial({
         // Lower default bone opacity so bones appear less prominent
         boneOpacity: { value: 0.5 },
         resolution: { value: new THREE.Vector2(window.innerWidth, window.innerHeight) },
-        edgeStrength: { value: 1.0 }
+        edgeStrength: { value: 1.0 },
+        contrastOpacity: { value: 1.0 },
+        contrastGain: { value: 5.0 }
 
     },
     vertexShader: displayVS,
@@ -1145,6 +1150,21 @@ function withTransparentClear(renderer, fn) {
     renderer.setClearColor(0x000000, 1);
 }
 
+function renderOnlySceneObjects(scene, camera, objects) {
+    const keep = new Set(objects.filter(Boolean));
+    const hidden = [];
+    for (const child of scene.children) {
+        if (child.isCamera) continue;
+        const shouldRender = keep.has(child) && child.visible;
+        if (!shouldRender && child.visible) {
+            hidden.push(child);
+            child.visible = false;
+        }
+    }
+    renderer.render(scene, camera);
+    for (const obj of hidden) obj.visible = true;
+}
+
 function animate(time) {
     // Render loop: updates geometry, handles fluoroscopy accumulation, and UI
     const dt = (time - lastRenderTime) / 1000;
@@ -1229,9 +1249,24 @@ function animate(time) {
             renderer.render(contrastScene, camera);
         });
 
+        renderer.setRenderTarget(metalTarget);
+        withTransparentClear(renderer, () => {
+            renderer.clear();
+            renderOnlySceneObjects(scene, camera, [
+                wireMesh,
+                pigtailCatheter.mesh,
+                sheathFluoroMesh
+            ]);
+        });
+
         renderer.setRenderTarget(offscreenTarget);
         renderer.clear();
-        renderer.render(scene, camera);
+        renderOnlySceneObjects(scene, camera, [
+            skeletonModel,
+            sheathFluoroMesh,
+            wireMesh,
+            pigtailCatheter.mesh
+        ]);
 
         blendMaterial.uniforms.currentFrame.value = offscreenTarget.texture;
         blendMaterial.uniforms.previousFrame.value = previousTarget.texture;
@@ -1242,6 +1277,8 @@ function animate(time) {
 
         displayMaterial.uniforms.uTexture.value = currentTarget.texture;
         displayMaterial.uniforms.contrastTexture.value = contrastTarget.texture;
+        displayMaterial.uniforms.thicknessTexture.value = thicknessTarget.texture;
+        displayMaterial.uniforms.metalTexture.value = metalTarget.texture;
         displayMaterial.uniforms.time.value = time * 0.001;
         renderer.render(displayScene, postCamera);
 
@@ -1269,6 +1306,7 @@ window.addEventListener('resize', () => {
     camera.updateProjectionMatrix();
     offscreenTarget.setSize(w, h);
     contrastTarget.setSize(w, h);
+    metalTarget.setSize(w, h);
     accumulateTarget1.setSize(w, h);
     accumulateTarget2.setSize(w, h);
     frontDepthTarget.setSize(w, h);

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -53,8 +53,15 @@ export function initUI(options) {
   const injRateSlider = document.getElementById('injRate');
   const injDurationSlider = document.getElementById('injDuration');
   const injVolumeSlider = document.getElementById('injVolume');
+  const autoExposureToggle = document.getElementById('autoExposureToggle');
   const persistenceSlider = document.getElementById('persistence');
+  const pulseRateSlider = document.getElementById('pulseRate');
   const noiseSlider = document.getElementById('noiseLevel');
+  const scatterStrengthSlider = document.getElementById('scatterStrength');
+  const collimationSlider = document.getElementById('collimation');
+  const imageBrightnessSlider = document.getElementById('imageBrightness');
+  const imageContrastSlider = document.getElementById('imageContrast');
+  const edgeEnhancementSlider = document.getElementById('edgeEnhancement');
   const boneVisibilitySlider = document.getElementById('boneVisibility');
   const contrastOpacitySlider = document.getElementById('opacityScale');
   const contrastGainSlider = document.getElementById('gain');
@@ -65,6 +72,8 @@ export function initUI(options) {
   const catheterRotateLeftButton = document.getElementById('catheterRotateLeft');
   const catheterRotateRightButton = document.getElementById('catheterRotateRight');
   const doseDisplayEl = document.getElementById('currentDose');
+  const currentKVEl = document.getElementById('currentKV');
+  const currentMAEl = document.getElementById('currentMA');
   const guidewireResistanceEl = document.getElementById('guidewireResistanceStatus');
   const guidewireResistanceReasonEl = document.getElementById('guidewireResistanceReason');
   const guidewireResistanceValueEl = document.getElementById('guidewireResistanceValue');
@@ -83,7 +92,13 @@ export function initUI(options) {
     kineticFricSlider,
     smoothIterSlider,
     persistenceSlider,
+    pulseRateSlider,
     noiseSlider,
+    scatterStrengthSlider,
+    collimationSlider,
+    imageBrightnessSlider,
+    imageContrastSlider,
+    edgeEnhancementSlider,
     boneVisibilitySlider,
     contrastOpacitySlider,
     contrastGainSlider,
@@ -118,10 +133,62 @@ export function initUI(options) {
   });
 
   // Imaging controls
+  if (autoExposureToggle && displayMaterial.uniforms.autoExposureEnabled) {
+    let autoExposureEnabled = Boolean(displayMaterial.uniforms.autoExposureEnabled.value);
+    const updateAutoExposureToggle = () => {
+      displayMaterial.uniforms.autoExposureEnabled.value = autoExposureEnabled;
+      autoExposureToggle.textContent = `Auto exposure: ${autoExposureEnabled ? 'On' : 'Off'}`;
+      autoExposureToggle.classList.toggle('active', autoExposureEnabled);
+    };
+    updateAutoExposureToggle();
+    autoExposureToggle.addEventListener('click', () => {
+      autoExposureEnabled = !autoExposureEnabled;
+      updateAutoExposureToggle();
+      autoExposureToggle.blur();
+    });
+  }
   if (noiseSlider) {
     displayMaterial.uniforms.noiseLevel.value = parseFloat(noiseSlider.value);
     noiseSlider.addEventListener('input', e => {
       displayMaterial.uniforms.noiseLevel.value = parseFloat(e.target.value);
+    });
+  }
+  if (pulseRateSlider && displayMaterial.uniforms.pulseRate) {
+    const updatePulseRate = e => {
+      displayMaterial.uniforms.pulseRate.value = parseFloat(e.target.value);
+    };
+    displayMaterial.uniforms.pulseRate.value = parseFloat(pulseRateSlider.value);
+    pulseRateSlider.addEventListener('input', updatePulseRate);
+    pulseRateSlider.addEventListener('change', updatePulseRate);
+  }
+  if (scatterStrengthSlider && displayMaterial.uniforms.scatterStrength) {
+    displayMaterial.uniforms.scatterStrength.value = parseFloat(scatterStrengthSlider.value);
+    scatterStrengthSlider.addEventListener('input', e => {
+      displayMaterial.uniforms.scatterStrength.value = parseFloat(e.target.value);
+    });
+  }
+  if (collimationSlider && displayMaterial.uniforms.collimation) {
+    displayMaterial.uniforms.collimation.value = parseFloat(collimationSlider.value);
+    collimationSlider.addEventListener('input', e => {
+      displayMaterial.uniforms.collimation.value = parseFloat(e.target.value);
+    });
+  }
+  if (imageBrightnessSlider && displayMaterial.uniforms.imageBrightness) {
+    displayMaterial.uniforms.imageBrightness.value = parseFloat(imageBrightnessSlider.value);
+    imageBrightnessSlider.addEventListener('input', e => {
+      displayMaterial.uniforms.imageBrightness.value = parseFloat(e.target.value);
+    });
+  }
+  if (imageContrastSlider && displayMaterial.uniforms.imageContrast) {
+    displayMaterial.uniforms.imageContrast.value = parseFloat(imageContrastSlider.value);
+    imageContrastSlider.addEventListener('input', e => {
+      displayMaterial.uniforms.imageContrast.value = parseFloat(e.target.value);
+    });
+  }
+  if (edgeEnhancementSlider && displayMaterial.uniforms.edgeStrength) {
+    displayMaterial.uniforms.edgeStrength.value = parseFloat(edgeEnhancementSlider.value);
+    edgeEnhancementSlider.addEventListener('input', e => {
+      displayMaterial.uniforms.edgeStrength.value = parseFloat(e.target.value);
     });
   }
   if (persistenceSlider) {
@@ -306,6 +373,10 @@ export function initUI(options) {
   function updateDose(ml) {
     if (doseDisplayEl) doseDisplayEl.textContent = ml.toFixed(1) + ' ml';
   }
+  function updateXrayTechnique(kv, ma) {
+    if (currentKVEl) currentKVEl.textContent = `${Math.round(kv)} kV`;
+    if (currentMAEl) currentMAEl.textContent = `${ma.toFixed(1)} mA`;
+  }
   function updateGuidewireResistance(level, reason = '') {
     if (!guidewireResistanceEl) return;
     if (level < 0.35) {
@@ -350,6 +421,7 @@ export function initUI(options) {
     updateInsertedLength,
     updateCatheterLength,
     updateDose,
+    updateXrayTechnique,
     updateGuidewireResistance,
     setInjectButtonDisabled,
     setStopInjectionDisabled,

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -55,6 +55,9 @@ export function initUI(options) {
   const injVolumeSlider = document.getElementById('injVolume');
   const persistenceSlider = document.getElementById('persistence');
   const noiseSlider = document.getElementById('noiseLevel');
+  const boneVisibilitySlider = document.getElementById('boneVisibility');
+  const contrastOpacitySlider = document.getElementById('opacityScale');
+  const contrastGainSlider = document.getElementById('gain');
   const insertedLengthEl = document.getElementById('insertedLength');
   const catheterLengthEl = document.getElementById('catheterLength');
   const catheterAdvanceButton = document.getElementById('catheterAdvance');
@@ -81,6 +84,9 @@ export function initUI(options) {
     smoothIterSlider,
     persistenceSlider,
     noiseSlider,
+    boneVisibilitySlider,
+    contrastOpacitySlider,
+    contrastGainSlider,
     injVolumeSlider,
     injRateSlider,
     injDurationSlider
@@ -122,6 +128,24 @@ export function initUI(options) {
     blendMaterial.uniforms.decay.value = parseFloat(persistenceSlider.value);
     persistenceSlider.addEventListener('input', e => {
       blendMaterial.uniforms.decay.value = parseFloat(e.target.value);
+    });
+  }
+  if (boneVisibilitySlider && displayMaterial.uniforms.boneOpacity) {
+    displayMaterial.uniforms.boneOpacity.value = parseFloat(boneVisibilitySlider.value);
+    boneVisibilitySlider.addEventListener('input', e => {
+      displayMaterial.uniforms.boneOpacity.value = parseFloat(e.target.value);
+    });
+  }
+  if (contrastOpacitySlider && displayMaterial.uniforms.contrastOpacity) {
+    displayMaterial.uniforms.contrastOpacity.value = parseFloat(contrastOpacitySlider.value) / 100;
+    contrastOpacitySlider.addEventListener('input', e => {
+      displayMaterial.uniforms.contrastOpacity.value = parseFloat(e.target.value) / 100;
+    });
+  }
+  if (contrastGainSlider && displayMaterial.uniforms.contrastGain) {
+    displayMaterial.uniforms.contrastGain.value = parseFloat(contrastGainSlider.value);
+    contrastGainSlider.addEventListener('input', e => {
+      displayMaterial.uniforms.contrastGain.value = parseFloat(e.target.value);
     });
   }
 

--- a/style.css
+++ b/style.css
@@ -41,6 +41,19 @@ canvas {
     line-height: 1.25;
 }
 
+.xray-technique {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    margin: 4px 0 6px;
+    padding: 4px 6px;
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    background: rgba(255, 255, 255, 0.09);
+    font-weight: bold;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.15;
+}
+
 .guidewire-resistance {
     margin: 6px 0 4px;
     padding: 5px 6px;
@@ -112,6 +125,21 @@ canvas {
     margin-top: 4px;
     font-size: 11px;
     opacity: 0.75;
+}
+
+.imaging-toggle {
+    width: 100%;
+    min-height: 28px;
+    margin: 0 0 7px;
+    border: 1px solid rgba(255, 255, 255, 0.32);
+    background: rgba(255, 255, 255, 0.12);
+    color: white;
+    font-weight: bold;
+}
+
+.imaging-toggle.active {
+    border-color: rgba(115, 180, 255, 0.86);
+    background: rgba(40, 118, 255, 0.45);
 }
 
 #carmZButtons {


### PR DESCRIPTION
## Co zmieniono

- Rozbudowano shader fluoroskopii o bardziej realistyczne tłumienie tkanek, kości i warstwy korowej.
- Dodano zależność obrazu kości od grubości, przez którą przechodzą promienie w aktualnym ustawieniu C-arm.
- Dodano regulacje Imaging: brightness, contrast, edge enhancement, scatter, collimation, pulse fluoro oraz przełącznik auto exposure.
- Dodano bieżący odczyt kV i mA oraz sprzężenie kolimacji z autoekspozycją i mA.
- Zmniejszono nieprzezierność koszulki w fluoroskopii.

## Dlaczego

Celem było przybliżenie wyglądu obrazu do rzeczywistej fluoroskopii z ramienia C: subtelniejsze kości, widoczna lecz nieprzerysowana kora, bardziej miękki obraz oraz zachowanie zależne od ustawienia projekcji i kolimacji.

## Wpływ

Użytkownik może stroić parametry obrazu bez zmian w kodzie, a symulowany odczyt techniki RTG reaguje teraz bardziej wiarygodnie na kolimację, pulse rate i auto exposure.

## Walidacja

- `node --check src/simulator.js`
- test w przeglądarce na `http://localhost:4180/?bone=20`
- sprawdzono brak błędów w konsoli
- sprawdzono wpływ kolimacji na mA: pełne pole ok. `2.8 mA`, mocna kolimacja ok. `1.5 mA`