### PR TITLE
[codex] Fix dev UI layout widths

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Endovascular Trainer</title>
-    <link rel="stylesheet" href="style.css?v=20260618prmerge1">
+    <link rel="stylesheet" href="style.css?v=20260618layoutfix1">
 </head>
 <body>
 <canvas id="sim"></canvas>

--- a/style.css
+++ b/style.css
@@ -20,7 +20,8 @@ canvas {
     position: absolute;
     top: 430px;
     right: 10px;
-    width: min(310px, calc(100vw - 240px));
+    width: 310px;
+    max-width: calc(100vw - 240px);
     min-width: 260px;
     box-sizing: border-box;
 }
@@ -380,7 +381,8 @@ canvas {
     position: absolute;
     top: 10px;
     right: 10px;
-    width: min(310px, calc(100vw - 240px));
+    width: 310px;
+    max-width: calc(100vw - 240px);
     min-width: 260px;
     color: #d8dfdc;
     font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -620,7 +622,8 @@ canvas {
     position: absolute;
     top: 220px;
     right: 10px;
-    width: min(310px, calc(100vw - 240px));
+    width: 310px;
+    max-width: calc(100vw - 240px);
     min-width: 260px;
     height: 200px;
     box-sizing: border-box;


### PR DESCRIPTION
## Summary
- Replace `width: min(...)` on the monitor, C-arm preview, and C-arm controls with stable fixed widths plus `max-width`.
- Bump the stylesheet cache key so browsers load the corrected layout CSS.

## Why
After merging the updated patient monitor into `dev`, the monitor panel could compute to an enormous width in the browser, covering the left controls and breaking the UI layout.

## Validation
- Verified in the browser after reload: controls, monitor, C-arm preview, and C-arm controls render in normal positions.
- `npm test`