### PR TITLE
[codex] Optimize guidewire physics hot paths

### DIFF
--- a/src/aortaModel.js
+++ b/src/aortaModel.js
@@ -96,17 +96,60 @@ export function createAortaModel(vessel, { onLoaded, onError } = {}) {
 }
 
 export function createMeshLumenCollider(geometry, { lumenField = null } = {}) {
-    function pointContact(input, clearance = 0) {
-        const query = lumenField?.query?.(input);
-        if (!query) return {
-            inside: true,
-            violation: false,
-            distance: Infinity,
-            signedDistance: Infinity,
-            target: new THREE.Vector3(input.x, input.y, input.z),
-            normal: new THREE.Vector3(1, 0, 0)
-        };
+    const setPoint = (target, x, y, z) => {
+        if (typeof target?.set === 'function') target.set(x, y, z);
+        else {
+            target.x = x;
+            target.y = y;
+            target.z = z;
+        }
+        return target;
+    };
+
+    function pointContact(input, clearance = 0, out = null) {
+        const query = lumenField?.query?.(input, out?.query);
+        if (!query) {
+            if (out) {
+                out.inside = true;
+                out.violation = false;
+                out.distance = Infinity;
+                out.signedDistance = Infinity;
+                out.target = setPoint(out.target || (out.target = {}), input.x, input.y, input.z);
+                out.normal = setPoint(out.normal || (out.normal = {}), 1, 0, 0);
+                return out;
+            }
+            return {
+                inside: true,
+                violation: false,
+                distance: Infinity,
+                signedDistance: Infinity,
+                target: new THREE.Vector3(input.x, input.y, input.z),
+                normal: new THREE.Vector3(1, 0, 0)
+            };
+        }
         const violation = query.signedDistance < clearance;
+        if (out) {
+            out.inside = query.inside;
+            out.violation = violation;
+            out.distance = Math.max(0, query.signedDistance);
+            out.signedDistance = query.signedDistance;
+            out.target = out.target || {};
+            if (violation) {
+                const correction = Math.max(0, clearance - query.signedDistance);
+                setPoint(
+                    out.target,
+                    input.x + query.inward.x * correction,
+                    input.y + query.inward.y * correction,
+                    input.z + query.inward.z * correction
+                );
+            } else {
+                setPoint(out.target, input.x, input.y, input.z);
+            }
+            out.closestPoint = setPoint(out.closestPoint || (out.closestPoint = {}), query.closestPoint.x, query.closestPoint.y, query.closestPoint.z);
+            out.inward = setPoint(out.inward || (out.inward = {}), query.inward.x, query.inward.y, query.inward.z);
+            out.normal = setPoint(out.normal || (out.normal = {}), query.normal.x, query.normal.y, query.normal.z);
+            return out;
+        }
         return {
             inside: query.inside,
             violation,

--- a/src/aortaPreprocess.js
+++ b/src/aortaPreprocess.js
@@ -125,13 +125,17 @@ function polygonCentroid(points) {
 }
 
 function pointInPolygon(point, polygon) {
+    return pointInPolygonCoords(point.x, point.z, polygon);
+}
+
+function pointInPolygonCoords(x, z, polygon) {
     let inside = false;
     for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
         const a = polygon[i];
         const b = polygon[j];
         if (
-            (a.z > point.z) !== (b.z > point.z) &&
-            point.x < (b.x - a.x) * (point.z - a.z) / (b.z - a.z + 1e-12) + a.x
+            (a.z > z) !== (b.z > z) &&
+            x < (b.x - a.x) * (z - a.z) / (b.z - a.z + 1e-12) + a.x
         ) {
             inside = !inside;
         }
@@ -183,6 +187,36 @@ function closestPointOnPolygon(point, polygon) {
     return best || { point: { x: point.x, z: point.z }, distanceSq: 0 };
 }
 
+function closestPointOnPolygonCoords(x, z, polygon, out) {
+    let bestX = x;
+    let bestZ = z;
+    let bestDistanceSq = Infinity;
+
+    for (let i = 0; i < polygon.length; i++) {
+        const a = polygon[i];
+        const b = polygon[(i + 1) % polygon.length];
+        const dx = b.x - a.x;
+        const dz = b.z - a.z;
+        const lengthSq = dx * dx + dz * dz || 1;
+        const t = Math.max(0, Math.min(1, ((x - a.x) * dx + (z - a.z) * dz) / lengthSq));
+        const cx = a.x + dx * t;
+        const cz = a.z + dz * t;
+        const px = x - cx;
+        const pz = z - cz;
+        const distanceSq = px * px + pz * pz;
+        if (distanceSq < bestDistanceSq) {
+            bestDistanceSq = distanceSq;
+            bestX = cx;
+            bestZ = cz;
+        }
+    }
+
+    out.x = bestX;
+    out.z = bestZ;
+    out.distanceSq = Number.isFinite(bestDistanceSq) ? bestDistanceSq : 0;
+    return out;
+}
+
 function polygonBounds(points) {
     const bounds = {
         minX: Infinity,
@@ -226,15 +260,19 @@ function simplifyClosedPolygon(points, tolerance = FIELD_POLYGON_SIMPLIFY_TOLERA
 }
 
 function boundsDistanceSq(point, bounds) {
-    const dx = point.x < bounds.minX
-        ? bounds.minX - point.x
-        : point.x > bounds.maxX
-            ? point.x - bounds.maxX
+    return boundsDistanceSqCoords(point.x, point.z, bounds);
+}
+
+function boundsDistanceSqCoords(x, z, bounds) {
+    const dx = x < bounds.minX
+        ? bounds.minX - x
+        : x > bounds.maxX
+            ? x - bounds.maxX
             : 0;
-    const dz = point.z < bounds.minZ
-        ? bounds.minZ - point.z
-        : point.z > bounds.maxZ
-            ? point.z - bounds.maxZ
+    const dz = z < bounds.minZ
+        ? bounds.minZ - z
+        : z > bounds.maxZ
+            ? z - bounds.maxZ
             : 0;
     return dx * dx + dz * dz;
 }
@@ -264,6 +302,57 @@ function signedDistanceToContour(point, contour) {
         closestPoint: closest.point,
         contour
     };
+}
+
+function createSliceQueryScratch() {
+    return {
+        signedDistance: -Infinity,
+        inside: false,
+        inward: { x: 1, z: 0 },
+        closestPoint: { x: 0, z: 0 },
+        contour: null,
+        _closest: { x: 0, z: 0, distanceSq: 0 },
+        _candidate: null
+    };
+}
+
+function copySliceQuery(target, source) {
+    target.signedDistance = source.signedDistance;
+    target.inside = source.inside;
+    target.inward.x = source.inward.x;
+    target.inward.z = source.inward.z;
+    target.closestPoint.x = source.closestPoint.x;
+    target.closestPoint.z = source.closestPoint.z;
+    target.contour = source.contour;
+    return target;
+}
+
+function signedDistanceToContourCoords(x, z, contour, out) {
+    const closest = closestPointOnPolygonCoords(x, z, contour.polygon, out._closest);
+    const distance = Math.sqrt(closest.distanceSq);
+    const inside = pointInPolygonCoords(x, z, contour.polygon);
+    let inwardX = inside ? x - closest.x : closest.x - x;
+    let inwardZ = inside ? z - closest.z : closest.z - z;
+    const length = Math.hypot(inwardX, inwardZ);
+    if (length > 1e-8) {
+        inwardX /= length;
+        inwardZ /= length;
+    } else {
+        inwardX = contour.sample.x - closest.x;
+        inwardZ = contour.sample.z - closest.z;
+        const fallbackLength = Math.hypot(inwardX, inwardZ) || 1;
+        inwardX /= fallbackLength;
+        inwardZ /= fallbackLength;
+    }
+
+    out.signedDistance = inside ? distance : -distance;
+    out.inside = inside;
+    out.inward.x = inwardX;
+    out.inward.z = inwardZ;
+    out.closestPoint.x = closest.x;
+    out.closestPoint.z = closest.z;
+    out.contour = contour;
+    return out;
 }
 
 function bestInteriorPoint(polygon) {
@@ -486,23 +575,47 @@ function buildLumenContourDebugSegments(slices) {
     return new Float32Array(positions);
 }
 
-function querySlice(slice, x, z) {
-    const point = { x, z };
-    let best = null;
+function querySlice(slice, x, z, out = null) {
+    const point = out ? null : { x, z };
+    const candidateScratch = out
+        ? (out._candidate || (out._candidate = createSliceQueryScratch()))
+        : null;
+    let best = out || null;
+    let hasBest = false;
+
     for (const contour of slice.contours) {
-        const boundDistanceSq = boundsDistanceSq(point, contour.bounds);
+        const boundDistanceSq = out
+            ? boundsDistanceSqCoords(x, z, contour.bounds)
+            : boundsDistanceSq(point, contour.bounds);
         if (
-            best &&
+            hasBest &&
             best.signedDistance < 0 &&
             -Math.sqrt(boundDistanceSq) <= best.signedDistance
         ) {
             continue;
         }
 
-        const candidate = signedDistanceToContour(point, contour);
-        if (!best || candidate.signedDistance > best.signedDistance) best = candidate;
+        const candidate = out
+            ? signedDistanceToContourCoords(x, z, contour, candidateScratch)
+            : signedDistanceToContour(point, contour);
+        if (!hasBest || candidate.signedDistance > best.signedDistance) {
+            best = out ? copySliceQuery(out, candidate) : candidate;
+            hasBest = true;
+        }
     }
-    return best || {
+
+    if (hasBest) return best;
+    if (out) {
+        out.signedDistance = -Infinity;
+        out.inside = false;
+        out.inward.x = 1;
+        out.inward.z = 0;
+        out.closestPoint.x = x;
+        out.closestPoint.z = z;
+        out.contour = null;
+        return out;
+    }
+    return {
         signedDistance: -Infinity,
         inside: false,
         inward: { x: 1, z: 0 },
@@ -511,11 +624,38 @@ function querySlice(slice, x, z) {
     };
 }
 
-function findSliceInterval(slices, y) {
-    if (slices.length <= 1) return { lower: 0, upper: 0, t: 0 };
-    if (y <= slices[0].y) return { lower: 0, upper: 0, t: 0 };
+function setSliceInterval(out, lower, upper, t) {
+    if (!out) return { lower, upper, t };
+    out.lower = lower;
+    out.upper = upper;
+    out.t = t;
+    return out;
+}
+
+function findSliceInterval(slices, y, out = null) {
+    if (slices.length <= 1) return setSliceInterval(out, 0, 0, 0);
+    if (y <= slices[0].y) return setSliceInterval(out, 0, 0, 0);
     const last = slices.length - 1;
-    if (y >= slices[last].y) return { lower: last, upper: last, t: 0 };
+    if (y >= slices[last].y) return setSliceInterval(out, last, last, 0);
+
+    if (out && Number.isInteger(out.lower) && Number.isInteger(out.upper)) {
+        let lower = Math.max(0, Math.min(last, out.lower));
+        let upper = Math.max(0, Math.min(last, out.upper));
+        if (upper < lower) upper = lower;
+
+        while (lower > 0 && y < slices[lower].y) {
+            upper = lower;
+            lower--;
+        }
+        while (upper < last && y > slices[upper].y) {
+            lower = upper;
+            upper++;
+        }
+        if (lower !== upper && slices[lower].y <= y && y <= slices[upper].y) {
+            const span = Math.max(1e-6, slices[upper].y - slices[lower].y);
+            return setSliceInterval(out, lower, upper, Math.max(0, Math.min(1, (y - slices[lower].y) / span)));
+        }
+    }
 
     let lo = 0;
     let hi = last;
@@ -525,11 +665,7 @@ function findSliceInterval(slices, y) {
         else hi = mid;
     }
     const span = Math.max(1e-6, slices[hi].y - slices[lo].y);
-    return {
-        lower: lo,
-        upper: hi,
-        t: Math.max(0, Math.min(1, (y - slices[lo].y) / span))
-    };
+    return setSliceInterval(out, lo, hi, Math.max(0, Math.min(1, (y - slices[lo].y) / span)));
 }
 
 function normalize3(x, y, z, fallback = { x: 1, y: 0, z: 0 }) {
@@ -538,17 +674,40 @@ function normalize3(x, y, z, fallback = { x: 1, y: 0, z: 0 }) {
     return { x: x / length, y: y / length, z: z / length };
 }
 
+function setVectorLike(target, x, y, z) {
+    if (typeof target?.set === 'function') {
+        target.set(x, y, z);
+    } else {
+        target.x = x;
+        target.y = y;
+        target.z = z;
+    }
+    return target;
+}
+
 export function createLumenField(lumenSlices) {
     const slices = (lumenSlices || [])
         .filter(slice => slice?.contours?.length)
         .slice()
         .sort((a, b) => a.y - b.y);
+    const intervalCache = { lower: 0, upper: 0, t: 0 };
+    const lowerScratch = createSliceQueryScratch();
+    const upperScratch = createSliceQueryScratch();
 
-    function query(input) {
+    function query(input, out = null) {
         const x = input.x;
         const y = input.y;
         const z = input.z;
         if (!slices.length) {
+            if (out) {
+                out.inside = false;
+                out.signedDistance = -Infinity;
+                out.distance = Infinity;
+                out.inward = setVectorLike(out.inward || (out.inward = {}), 1, 0, 0);
+                out.normal = setVectorLike(out.normal || (out.normal = {}), -1, 0, 0);
+                out.closestPoint = setVectorLike(out.closestPoint || (out.closestPoint = {}), x, y, z);
+                return out;
+            }
             const fallback = new THREE.Vector3(1, 0, 0);
             return {
                 inside: false,
@@ -561,24 +720,45 @@ export function createLumenField(lumenSlices) {
             };
         }
 
-        const interval = findSliceInterval(slices, y);
+        const interval = findSliceInterval(slices, y, out ? intervalCache : null);
         const lowerSlice = slices[interval.lower];
         const upperSlice = slices[interval.upper];
-        const lower = querySlice(lowerSlice, x, z);
+        const lower = querySlice(lowerSlice, x, z, out ? lowerScratch : null);
         const upper = interval.upper === interval.lower
             ? lower
-            : querySlice(upperSlice, x, z);
+            : querySlice(upperSlice, x, z, out ? upperScratch : null);
         const t = interval.t;
         const signedDistance = lower.signedDistance * (1 - t) + upper.signedDistance * t;
         const dy = Math.max(1e-6, Math.abs(upperSlice.y - lowerSlice.y));
         const yGradient = interval.upper === interval.lower
             ? 0
             : Math.max(-0.85, Math.min(0.85, (upper.signedDistance - lower.signedDistance) / dy));
-        const inward = normalize3(
-            lower.inward.x * (1 - t) + upper.inward.x * t,
-            yGradient,
-            lower.inward.z * (1 - t) + upper.inward.z * t
-        );
+        const rawInwardX = lower.inward.x * (1 - t) + upper.inward.x * t;
+        const rawInwardY = yGradient;
+        const rawInwardZ = lower.inward.z * (1 - t) + upper.inward.z * t;
+        const inwardLength = Math.hypot(rawInwardX, rawInwardY, rawInwardZ);
+        const inwardX = inwardLength < 1e-8 ? 1 : rawInwardX / inwardLength;
+        const inwardY = inwardLength < 1e-8 ? 0 : rawInwardY / inwardLength;
+        const inwardZ = inwardLength < 1e-8 ? 0 : rawInwardZ / inwardLength;
+
+        if (out) {
+            out.inside = signedDistance >= 0;
+            out.signedDistance = signedDistance;
+            out.distance = Math.abs(signedDistance);
+            out.inward = setVectorLike(out.inward || (out.inward = {}), inwardX, inwardY, inwardZ);
+            out.normal = setVectorLike(out.normal || (out.normal = {}), -inwardX, -inwardY, -inwardZ);
+            out.closestPoint = setVectorLike(
+                out.closestPoint || (out.closestPoint = {}),
+                x - inwardX * signedDistance,
+                y - inwardY * signedDistance,
+                z - inwardZ * signedDistance
+            );
+            out.lowerSlice = lowerSlice;
+            out.upperSlice = upperSlice;
+            return out;
+        }
+
+        const inward = { x: inwardX, y: inwardY, z: inwardZ };
         const closestPoint = new THREE.Vector3(
             x - inward.x * signedDistance,
             y - inward.y * signedDistance,

--- a/src/physics/elasticRod.js
+++ b/src/physics/elasticRod.js
@@ -60,6 +60,123 @@ const DEFAULT_MESH_COLLISION_PASSES = 2;
 const VOLUME_SEGMENT_SAMPLES = [0.25, 0.5, 0.75];
 const MESH_COLLIDER_SEGMENT_SAMPLES = [0.25, 0.5, 0.75];
 
+function ensurePointBuffer(buffer, count) {
+    if (!buffer || buffer.length !== count) {
+        return Array.from({ length: count }, () => ({ x: 0, y: 0, z: 0, active: false }));
+    }
+    return buffer;
+}
+
+function snapshotNodePositions(nodes, buffer) {
+    const positions = ensurePointBuffer(buffer, nodes.length);
+    const storage = nodes.nodeStorage;
+    if (storage) {
+        const { x, y, z } = storage;
+        for (let i = 0; i < nodes.length; i++) {
+            const position = positions[i];
+            position.x = x[i];
+            position.y = y[i];
+            position.z = z[i];
+            position.active = true;
+        }
+        return positions;
+    }
+    for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i];
+        const position = positions[i];
+        position.x = node.x;
+        position.y = node.y;
+        position.z = node.z;
+        position.active = true;
+    }
+    return positions;
+}
+
+function clearPointBuffer(buffer) {
+    for (let i = 0; i < buffer.length; i++) {
+        const point = buffer[i];
+        point.x = 0;
+        point.y = 0;
+        point.z = 0;
+        point.active = false;
+    }
+}
+
+function createNodeStorage(count, mass, bendingStiffness) {
+    const storage = {
+        x: new Float64Array(count),
+        y: new Float64Array(count),
+        z: new Float64Array(count),
+        vx: new Float64Array(count),
+        vy: new Float64Array(count),
+        vz: new Float64Array(count),
+        fx: new Float64Array(count),
+        fy: new Float64Array(count),
+        fz: new Float64Array(count),
+        kx: new Float64Array(count),
+        ky: new Float64Array(count),
+        kz: new Float64Array(count),
+        mass: new Float64Array(count),
+        bendingStiffness: new Float64Array(count),
+        pinned: new Uint8Array(count)
+    };
+    storage.mass.fill(mass);
+    storage.bendingStiffness.fill(bendingStiffness);
+    return storage;
+}
+
+class RodNodeView {
+    constructor(storage, index) {
+        this._storage = storage;
+        this.index = index;
+    }
+
+    get x() { return this._storage.x[this.index]; }
+    set x(value) { this._storage.x[this.index] = value; }
+
+    get y() { return this._storage.y[this.index]; }
+    set y(value) { this._storage.y[this.index] = value; }
+
+    get z() { return this._storage.z[this.index]; }
+    set z(value) { this._storage.z[this.index] = value; }
+
+    get vx() { return this._storage.vx[this.index]; }
+    set vx(value) { this._storage.vx[this.index] = value; }
+
+    get vy() { return this._storage.vy[this.index]; }
+    set vy(value) { this._storage.vy[this.index] = value; }
+
+    get vz() { return this._storage.vz[this.index]; }
+    set vz(value) { this._storage.vz[this.index] = value; }
+
+    get fx() { return this._storage.fx[this.index]; }
+    set fx(value) { this._storage.fx[this.index] = value; }
+
+    get fy() { return this._storage.fy[this.index]; }
+    set fy(value) { this._storage.fy[this.index] = value; }
+
+    get fz() { return this._storage.fz[this.index]; }
+    set fz(value) { this._storage.fz[this.index] = value; }
+
+    get mass() { return this._storage.mass[this.index]; }
+    set mass(value) { this._storage.mass[this.index] = value; }
+
+    get bendingStiffness() { return this._storage.bendingStiffness[this.index]; }
+    set bendingStiffness(value) { this._storage.bendingStiffness[this.index] = value; }
+
+    get kx() { return this._storage.kx[this.index]; }
+    set kx(value) { this._storage.kx[this.index] = value; }
+
+    get ky() { return this._storage.ky[this.index]; }
+    set ky(value) { this._storage.ky[this.index] = value; }
+
+    get kz() { return this._storage.kz[this.index]; }
+    set kz(value) { this._storage.kz[this.index] = value; }
+
+    get pinned() { return this._storage.pinned[this.index] !== 0; }
+    set pinned(value) { this._storage.pinned[this.index] = value ? 1 : 0; }
+}
+
 export class ElasticRod {
     constructor(count, segmentLength, {
         mass = 1,
@@ -73,7 +190,9 @@ export class ElasticRod {
         logger = null,
     } = {}) {
         this.segmentLength = segmentLength;
-        this.nodes = [];
+        this.nodeStorage = createNodeStorage(count, mass, bendingStiffness);
+        this.nodes = Array.from({ length: count }, (_, index) => new RodNodeView(this.nodeStorage, index));
+        this.nodes.nodeStorage = this.nodeStorage;
         this.smoothingIterations = smoothingIterations;
         this.constraintIterations = constraintIterations;
         this.bendingConstraintIterations = bendingConstraintIterations;
@@ -83,63 +202,57 @@ export class ElasticRod {
         this.logger = logger;
         this.iteration = 0;
         this.collisionPrevPositions = null;
+        this._constraintPrevPositions = null;
+        this._bendingCorrections = null;
+        this._smoothPositions = null;
+        this._tensionCorrections = null;
         for (let i = 0; i < count; i++) {
-            const x = i * segmentLength;
-            const y = 0, z = 0;
-            this.nodes.push({
-                x, y, z,
-                vx: 0, vy: 0, vz: 0,
-                fx: 0, fy: 0, fz: 0,
-                mass,
-                bendingStiffness,
-                kx: 0, ky: 0, kz: 0,
-                pinned: false,
-            });
+            this.nodeStorage.x[i] = i * segmentLength;
         }
     }
 
     storeCollisionPreviousPositions() {
+        const { x, y, z } = this.nodeStorage;
         if (!this.collisionPrevPositions || this.collisionPrevPositions.length !== this.nodes.length) {
-            this.collisionPrevPositions = this.nodes.map(n => new THREE.Vector3(n.x, n.y, n.z));
+            this.collisionPrevPositions = Array.from(
+                { length: this.nodes.length },
+                (_, i) => new THREE.Vector3(x[i], y[i], z[i])
+            );
             return;
         }
 
         for (let i = 0; i < this.nodes.length; i++) {
-            const n = this.nodes[i];
-            this.collisionPrevPositions[i].set(n.x, n.y, n.z);
+            this.collisionPrevPositions[i].set(x[i], y[i], z[i]);
         }
     }
 
     computeLength() {
+        const { x, y, z } = this.nodeStorage;
         let total = 0;
         for (let i = 0; i < this.nodes.length - 1; i++) {
-            const n0 = this.nodes[i];
-            const n1 = this.nodes[i + 1];
-            total += Math.hypot(n1.x - n0.x, n1.y - n0.y, n1.z - n0.z);
+            total += Math.hypot(x[i + 1] - x[i], y[i + 1] - y[i], z[i + 1] - z[i]);
         }
         return total;
     }
 
     averageCurvature() {
+        const { kx, ky, kz } = this.nodeStorage;
         let sum = 0;
-        for (const n of this.nodes) {
-            sum += Math.hypot(n.kx, n.ky, n.kz);
+        for (let i = 0; i < this.nodes.length; i++) {
+            sum += Math.hypot(kx[i], ky[i], kz[i]);
         }
         return sum / this.nodes.length;
     }
 
     bendAngleAt(index) {
-        const prev = this.nodes[index - 1];
-        const curr = this.nodes[index];
-        const next = this.nodes[index + 1];
-        if (!prev || !curr || !next) return 0;
-
-        const ax = curr.x - prev.x;
-        const ay = curr.y - prev.y;
-        const az = curr.z - prev.z;
-        const bx = next.x - curr.x;
-        const by = next.y - curr.y;
-        const bz = next.z - curr.z;
+        if (index <= 0 || index >= this.nodes.length - 1) return 0;
+        const { x, y, z } = this.nodeStorage;
+        const ax = x[index] - x[index - 1];
+        const ay = y[index] - y[index - 1];
+        const az = z[index] - z[index - 1];
+        const bx = x[index + 1] - x[index];
+        const by = y[index + 1] - y[index];
+        const bz = z[index + 1] - z[index];
         const aLen = Math.hypot(ax, ay, az);
         const bLen = Math.hypot(bx, by, bz);
         if (aLen < 1e-8 || bLen < 1e-8) return 0;
@@ -149,26 +262,23 @@ export class ElasticRod {
     }
 
     resetForces() {
-        for (const n of this.nodes) {
-            n.fx = n.fy = n.fz = 0;
-        }
+        this.nodeStorage.fx.fill(0);
+        this.nodeStorage.fy.fill(0);
+        this.nodeStorage.fz.fill(0);
     }
 
     // Compute discrete curvature vector for each interior node using
     // a second derivative approximation along the rod.
     updateCurvature() {
+        const { x, y, z, kx, ky, kz } = this.nodeStorage;
         const L2 = this.segmentLength * this.segmentLength;
-        // reset curvature
-        for (const n of this.nodes) {
-            n.kx = n.ky = n.kz = 0;
-        }
+        kx.fill(0);
+        ky.fill(0);
+        kz.fill(0);
         for (let i = 1; i < this.nodes.length - 1; i++) {
-            const p0 = this.nodes[i - 1];
-            const p1 = this.nodes[i];
-            const p2 = this.nodes[i + 1];
-            p1.kx = (p0.x - 2 * p1.x + p2.x) / L2;
-            p1.ky = (p0.y - 2 * p1.y + p2.y) / L2;
-            p1.kz = (p0.z - 2 * p1.z + p2.z) / L2;
+            kx[i] = (x[i - 1] - 2 * x[i] + x[i + 1]) / L2;
+            ky[i] = (y[i - 1] - 2 * y[i] + y[i + 1]) / L2;
+            kz[i] = (z[i - 1] - 2 * z[i] + z[i + 1]) / L2;
         }
     }
 
@@ -178,77 +288,62 @@ export class ElasticRod {
     accumulateBendingForces() {
         const count = this.nodes.length;
         if (count < 3) return;
+        const { fx: forceX, fy: forceY, fz: forceZ, kx, ky, kz, bendingStiffness } = this.nodeStorage;
         for (let i = 1; i < count - 1; i++) {
-            const prev = this.nodes[i - 1];
-            const curr = this.nodes[i];
-            const next = this.nodes[i + 1];
-            const prev2 = this.nodes[i - 2];
-            const next2 = this.nodes[i + 2];
-            const kx = curr.kx;
-            const ky = curr.ky;
-            const kz = curr.kz;
-
-            const EI = curr.bendingStiffness;
+            const curKx = kx[i];
+            const curKy = ky[i];
+            const curKz = kz[i];
+            const EI = bendingStiffness[i];
             // amplify straightening force when curvature is large
-            const k2 = kx * kx + ky * ky + kz * kz;
+            const k2 = curKx * curKx + curKy * curKy + curKz * curKz;
             const scale = 1 + k2; // nonlinear scaling for strong bends
-            const fx = EI * kx * scale;
-            const fy = EI * ky * scale;
-            const fz = EI * kz * scale;
+            const fx = EI * curKx * scale;
+            const fy = EI * curKy * scale;
+            const fz = EI * curKz * scale;
 
             // weights for immediate and next-nearest neighbours
             const w1 = 0.4;
             const w2 = 0.1;
-            if (prev2) {
-                prev2.fx += w2 * fx; prev2.fy += w2 * fy; prev2.fz += w2 * fz;
+            if (i >= 2) {
+                forceX[i - 2] += w2 * fx; forceY[i - 2] += w2 * fy; forceZ[i - 2] += w2 * fz;
             }
-            if (next2) {
-                next2.fx += w2 * fx; next2.fy += w2 * fy; next2.fz += w2 * fz;
+            if (i + 2 < count) {
+                forceX[i + 2] += w2 * fx; forceY[i + 2] += w2 * fy; forceZ[i + 2] += w2 * fz;
             }
-            prev.fx += w1 * fx; prev.fy += w1 * fy; prev.fz += w1 * fz;
-            next.fx += w1 * fx; next.fy += w1 * fy; next.fz += w1 * fz;
+            forceX[i - 1] += w1 * fx; forceY[i - 1] += w1 * fy; forceZ[i - 1] += w1 * fz;
+            forceX[i + 1] += w1 * fx; forceY[i + 1] += w1 * fy; forceZ[i + 1] += w1 * fz;
 
-            const sumWeights = w1 * 2 + (prev2 ? w2 : 0) + (next2 ? w2 : 0);
-            curr.fx -= sumWeights * fx;
-            curr.fy -= sumWeights * fy;
-            curr.fz -= sumWeights * fz;
+            const sumWeights = w1 * 2 + (i >= 2 ? w2 : 0) + (i + 2 < count ? w2 : 0);
+            forceX[i] -= sumWeights * fx;
+            forceY[i] -= sumWeights * fy;
+            forceZ[i] -= sumWeights * fz;
         }
     }
 
     // Integrate positions and velocities using semi-implicit Euler
     integrate(dt) {
-        for (const n of this.nodes) {
-            if (n.pinned) {
-                n.vx = n.vy = n.vz = 0;
+        const { x, y, z, vx, vy, vz, fx, fy, fz, mass, pinned } = this.nodeStorage;
+        for (let i = 0; i < this.nodes.length; i++) {
+            if (pinned[i]) {
+                vx[i] = 0;
+                vy[i] = 0;
+                vz[i] = 0;
                 continue;
             }
-            const ax = n.fx / n.mass;
-            const ay = n.fy / n.mass;
-            const az = n.fz / n.mass;
-            n.vx += ax * dt;
-            n.vy += ay * dt;
-            n.vz += az * dt;
-            n.x += n.vx * dt;
-            n.y += n.vy * dt;
-            n.z += n.vz * dt;
+            vx[i] += (fx[i] / mass[i]) * dt;
+            vy[i] += (fy[i] / mass[i]) * dt;
+            vz[i] += (fz[i] / mass[i]) * dt;
+            x[i] += vx[i] * dt;
+            y[i] += vy[i] * dt;
+            z[i] += vz[i] * dt;
         }
-    }
-
-    bendAngleAt(index) {
-        if (index <= 0 || index >= this.nodes.length - 1) return 0;
-        const prev = this.nodes[index - 1];
-        const curr = this.nodes[index];
-        const next = this.nodes[index + 1];
-        const a = new THREE.Vector3(prev.x - curr.x, prev.y - curr.y, prev.z - curr.z).normalize();
-        const b = new THREE.Vector3(next.x - curr.x, next.y - curr.y, next.z - curr.z).normalize();
-        const internalAngle = Math.acos(THREE.MathUtils.clamp(a.dot(b), -1, 1));
-        return 180 - THREE.MathUtils.radToDeg(internalAngle);
     }
 
     // Solve positional constraints and apply velocity damping
     solveConstraints(dt, options = {}) {
         const L = this.segmentLength;
-        const prev = this.nodes.map(n => ({ x: n.x, y: n.y, z: n.z }));
+        const prev = snapshotNodePositions(this.nodes, this._constraintPrevPositions);
+        this._constraintPrevPositions = prev;
         const applyBending = options.applyBending ?? true;
         const velocityDamping = options.velocityDamping ?? 0.92;
 
@@ -350,9 +445,11 @@ export class ElasticRod {
         if (iterations <= 0 || this.nodes.length < 3) return;
         const limit = Math.max(0, this.bendAngleLimit);
         const baseStrength = Math.max(0, Math.min(1, this.bendProjectionStrength));
+        this._bendingCorrections = ensurePointBuffer(this._bendingCorrections, this.nodes.length);
 
         for (let iter = 0; iter < iterations; iter++) {
-            const corrections = new Array(this.nodes.length);
+            const corrections = this._bendingCorrections;
+            clearPointBuffer(corrections);
             for (let i = 1; i < this.nodes.length - 1; i++) {
                 const n = this.nodes[i];
                 if (n.pinned) continue;
@@ -363,17 +460,17 @@ export class ElasticRod {
                 const next = this.nodes[i + 1];
                 const severity = Math.max(0, Math.min(1, (angle - limit) / Math.max(1, 180 - limit)));
                 const strength = baseStrength * (0.35 + 0.65 * severity);
-                corrections[i] = {
-                    x: ((prev.x + next.x) * 0.5 - n.x) * strength,
-                    y: ((prev.y + next.y) * 0.5 - n.y) * strength,
-                    z: ((prev.z + next.z) * 0.5 - n.z) * strength
-                };
+                const correction = corrections[i];
+                correction.x = ((prev.x + next.x) * 0.5 - n.x) * strength;
+                correction.y = ((prev.y + next.y) * 0.5 - n.y) * strength;
+                correction.z = ((prev.z + next.z) * 0.5 - n.z) * strength;
+                correction.active = true;
             }
 
             for (let i = 1; i < this.nodes.length - 1; i++) {
                 const n = this.nodes[i];
                 const c = corrections[i];
-                if (!c || n.pinned) continue;
+                if (!c.active || n.pinned) continue;
                 n.x += c.x;
                 n.y += c.y;
                 n.z += c.z;
@@ -385,26 +482,26 @@ export class ElasticRod {
     laplacianSmooth() {
         const count = this.nodes.length;
         if (count < 3) return;
+        this._smoothPositions = ensurePointBuffer(this._smoothPositions, count);
         for (let iter = 0; iter < this.smoothingIterations; iter++) {
-            const newPos = new Array(count);
+            const newPos = this._smoothPositions;
+            clearPointBuffer(newPos);
             for (let i = 1; i < count - 1; i++) {
                 const n = this.nodes[i];
-                if (n.pinned) {
-                    newPos[i] = { x: n.x, y: n.y, z: n.z };
-                    continue;
-                }
+                if (n.pinned) continue;
                 const p0 = this.nodes[i - 1];
                 const p2 = this.nodes[i + 1];
-                newPos[i] = {
-                    x: (p0.x + p2.x) * 0.5,
-                    y: (p0.y + p2.y) * 0.5,
-                    z: (p0.z + p2.z) * 0.5,
-                };
+                const target = newPos[i];
+                target.x = (p0.x + p2.x) * 0.5;
+                target.y = (p0.y + p2.y) * 0.5;
+                target.z = (p0.z + p2.z) * 0.5;
+                target.active = true;
             }
             for (let i = 1; i < count - 1; i++) {
                 const n = this.nodes[i];
                 if (n.pinned) continue;
                 const np = newPos[i];
+                if (!np.active) continue;
                 n.x = np.x; n.y = np.y; n.z = np.z;
             }
         }
@@ -414,23 +511,25 @@ export class ElasticRod {
         const count = this.nodes.length;
         if (count < 3 || strength <= 0 || iterations <= 0) return;
         const alpha = Math.max(0, Math.min(1, strength));
+        this._tensionCorrections = ensurePointBuffer(this._tensionCorrections, count);
         for (let iter = 0; iter < iterations; iter++) {
-            const corrections = new Array(count);
+            const corrections = this._tensionCorrections;
+            clearPointBuffer(corrections);
             for (let i = 1; i < count - 1; i++) {
                 const n = this.nodes[i];
                 if (n.pinned) continue;
                 const prev = this.nodes[i - 1];
                 const next = this.nodes[i + 1];
-                corrections[i] = {
-                    x: ((prev.x + next.x) * 0.5 - n.x) * alpha,
-                    y: ((prev.y + next.y) * 0.5 - n.y) * alpha,
-                    z: ((prev.z + next.z) * 0.5 - n.z) * alpha,
-                };
+                const correction = corrections[i];
+                correction.x = ((prev.x + next.x) * 0.5 - n.x) * alpha;
+                correction.y = ((prev.y + next.y) * 0.5 - n.y) * alpha;
+                correction.z = ((prev.z + next.z) * 0.5 - n.z) * alpha;
+                correction.active = true;
             }
             for (let i = 1; i < count - 1; i++) {
                 const n = this.nodes[i];
                 const c = corrections[i];
-                if (!c || n.pinned) continue;
+                if (!c.active || n.pinned) continue;
                 n.x += c.x;
                 n.y += c.y;
                 n.z += c.z;

--- a/src/physics/guidewireSolver.js
+++ b/src/physics/guidewireSolver.js
@@ -38,6 +38,7 @@ const DEFAULT_WITHDRAWAL_STRAIGHTENING_PASSES = 2;
 const DEFAULT_WITHDRAWAL_RELAX_FRAMES = 96;
 const DEFAULT_UNSUPPORTED_BEND_RELAX_ANGLE = 10;
 const DEFAULT_UNSUPPORTED_BEND_SUPPORT_BAND = 0.35;
+const DEFAULT_UNSUPPORTED_BEND_RELAX_FRAMES = 18;
 const SHEATH_BOUNDARY_EPSILON = 1e-3;
 
 function clamp(value, min, max) {
@@ -49,8 +50,68 @@ function smoothstep(edge0, edge1, value) {
     return t * t * (3 - 2 * t);
 }
 
-function copyNodePosition(node) {
-    return { x: node.x, y: node.y, z: node.z };
+function ensurePointBuffer(buffer, count) {
+    if (!buffer || buffer.length !== count) {
+        return Array.from({ length: count }, () => ({ x: 0, y: 0, z: 0, active: false }));
+    }
+    return buffer;
+}
+
+function snapshotNodePositions(nodes, buffer) {
+    const positions = ensurePointBuffer(buffer, nodes.length);
+    const storage = nodes.nodeStorage;
+    if (storage) {
+        const { x, y, z } = storage;
+        for (let i = 0; i < nodes.length; i++) {
+            const position = positions[i];
+            position.x = x[i];
+            position.y = y[i];
+            position.z = z[i];
+            position.active = true;
+        }
+        return positions;
+    }
+    for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i];
+        const position = positions[i];
+        position.x = node.x;
+        position.y = node.y;
+        position.z = node.z;
+        position.active = true;
+    }
+    return positions;
+}
+
+function clearPointBuffer(buffer) {
+    for (let i = 0; i < buffer.length; i++) {
+        const point = buffer[i];
+        point.x = 0;
+        point.y = 0;
+        point.z = 0;
+        point.active = false;
+    }
+}
+
+function addCorrection(buffer, index, x, y, z) {
+    const correction = buffer[index];
+    correction.x += x;
+    correction.y += y;
+    correction.z += z;
+    correction.active = true;
+}
+
+function createContactScratch() {
+    return {
+        query: {
+            inward: { x: 0, y: 0, z: 0 },
+            normal: { x: 0, y: 0, z: 0 },
+            closestPoint: { x: 0, y: 0, z: 0 }
+        },
+        target: { x: 0, y: 0, z: 0 },
+        closestPoint: { x: 0, y: 0, z: 0 },
+        inward: { x: 0, y: 0, z: 0 },
+        normal: { x: 0, y: 0, z: 0 }
+    };
 }
 
 function setNode(node, point) {
@@ -153,7 +214,8 @@ export class GuidewireSolver {
         withdrawalStraighteningPasses = DEFAULT_WITHDRAWAL_STRAIGHTENING_PASSES,
         withdrawalRelaxFrames = DEFAULT_WITHDRAWAL_RELAX_FRAMES,
         unsupportedBendRelaxAngle = DEFAULT_UNSUPPORTED_BEND_RELAX_ANGLE,
-        unsupportedBendSupportBand = DEFAULT_UNSUPPORTED_BEND_SUPPORT_BAND
+        unsupportedBendSupportBand = DEFAULT_UNSUPPORTED_BEND_SUPPORT_BAND,
+        unsupportedBendRelaxFrames = DEFAULT_UNSUPPORTED_BEND_RELAX_FRAMES
     }) {
         this.rod = rod;
         this.segmentLength = segmentLength;
@@ -199,14 +261,37 @@ export class GuidewireSolver {
         this.withdrawalRelaxFrames = withdrawalRelaxFrames;
         this.unsupportedBendRelaxAngle = unsupportedBendRelaxAngle;
         this.unsupportedBendSupportBand = unsupportedBendSupportBand;
+        this.unsupportedBendRelaxFrames = unsupportedBendRelaxFrames;
         this.tailProgress = 0;
         this.lastAdvanceDelta = 0;
         this.settleFramesRemaining = 0;
         this.withdrawalRelaxFramesRemaining = 0;
+        this.unsupportedBendRelaxFramesRemaining = 0;
+        this.unsupportedBendRelaxArmed = true;
         this.contactPoints = [];
         this.breachPoints = [];
         this.previousPositions = null;
         this.performanceStats = createPerformanceStats();
+        this._advancePreviousPositions = null;
+        this._solvePreviousPositions = null;
+        this._straightenCorrections = null;
+        this._spanCorrections = null;
+        this._untangleCorrections = null;
+        this._bendLimitCorrections = null;
+        this._diagnosticContact = createContactScratch();
+        this._supportContact = createContactScratch();
+        this._projectContact = createContactScratch();
+        this._slidePointContact = createContactScratch();
+        this._slideTargetContact = createContactScratch();
+        this._zeroVelocityContact = createContactScratch();
+        this._projectNodePoint = { x: 0, y: 0, z: 0 };
+        this._lumenConstraintState = {
+            projected: { x: 0, y: 0, z: 0 },
+            radialMargin: 0,
+            axialOffset: 0,
+            axialWindow: 0,
+            breach: false
+        };
 
         const sheathAxis = {
             x: sheath.end.x - sheath.start.x,
@@ -231,17 +316,33 @@ export class GuidewireSolver {
     }
 
     initialize() {
-        for (let i = 0; i < this.rod.nodes.length; i++) {
-            const distance = this.segmentLength * i;
-            const node = this.rod.nodes[i];
-            node.x = this.externalTailStart.x + this.sheathDir.x * distance;
-            node.y = this.externalTailStart.y + this.sheathDir.y * distance;
-            node.z = this.externalTailStart.z + this.sheathDir.z * distance;
-            node.vx = node.vy = node.vz = 0;
-            node.pinned = true;
+        const storage = this.rod.nodes.nodeStorage;
+        if (storage) {
+            const { x, y, z, vx, vy, vz, pinned } = storage;
+            for (let i = 0; i < this.rod.nodes.length; i++) {
+                const distance = this.segmentLength * i;
+                x[i] = this.externalTailStart.x + this.sheathDir.x * distance;
+                y[i] = this.externalTailStart.y + this.sheathDir.y * distance;
+                z[i] = this.externalTailStart.z + this.sheathDir.z * distance;
+                vx[i] = 0;
+                vy[i] = 0;
+                vz[i] = 0;
+                pinned[i] = 1;
+            }
+        } else {
+            for (let i = 0; i < this.rod.nodes.length; i++) {
+                const distance = this.segmentLength * i;
+                const node = this.rod.nodes[i];
+                node.x = this.externalTailStart.x + this.sheathDir.x * distance;
+                node.y = this.externalTailStart.y + this.sheathDir.y * distance;
+                node.z = this.externalTailStart.z + this.sheathDir.z * distance;
+                node.vx = node.vy = node.vz = 0;
+                node.pinned = true;
+            }
         }
         this.constrainSheath();
-        this.previousPositions = this.rod.nodes.map(copyNodePosition);
+        this.previousPositions = snapshotNodePositions(this.rod.nodes, this._advancePreviousPositions);
+        this._advancePreviousPositions = this.previousPositions;
     }
 
     insertedCoordinate(indexOrFloat) {
@@ -262,6 +363,21 @@ export class GuidewireSolver {
             0,
             this.rod.nodes.length
         );
+    }
+
+    #firstNodeOutsideSheathIndex() {
+        return clamp(
+            Math.floor(
+                (this.sheathLength + SHEATH_BOUNDARY_EPSILON + this.guidewireLength - this.tailProgress) /
+                this.segmentLength
+            ) + 1,
+            0,
+            this.rod.nodes.length
+        );
+    }
+
+    #firstSegmentOutsideSheathIndex() {
+        return Math.max(0, this.#firstNodeOutsideSheathIndex() - 1);
     }
 
     sheathAxisPoint(inserted) {
@@ -291,6 +407,24 @@ export class GuidewireSolver {
     }
 
     constrainSheath(feedSpeed = 0) {
+        const storage = this.rod.nodes.nodeStorage;
+        if (storage) {
+            const { x, y, z, vx, vy, vz, pinned } = storage;
+            const firstOutside = this.#firstNodeOutsideSheathIndex();
+            for (let i = 0; i < firstOutside; i++) {
+                const inserted = this.insertedCoordinate(i);
+                pinned[i] = 1;
+                x[i] = this.sheath.start.x + this.sheathDir.x * inserted;
+                y[i] = this.sheath.start.y + this.sheathDir.y * inserted;
+                z[i] = this.sheath.start.z + this.sheathDir.z * inserted;
+                vx[i] = this.sheathDir.x * feedSpeed;
+                vy[i] = this.sheathDir.y * feedSpeed;
+                vz[i] = this.sheathDir.z * feedSpeed;
+            }
+            pinned.fill(0, firstOutside);
+            return;
+        }
+
         for (let i = 0; i < this.rod.nodes.length; i++) {
             const inserted = this.insertedCoordinate(i);
             const node = this.rod.nodes[i];
@@ -298,8 +432,9 @@ export class GuidewireSolver {
             node.pinned = inSheath;
             if (!inSheath) continue;
 
-            const target = this.sheathAxisPoint(inserted);
-            setNode(node, target);
+            node.x = this.sheath.start.x + this.sheathDir.x * inserted;
+            node.y = this.sheath.start.y + this.sheathDir.y * inserted;
+            node.z = this.sheath.start.z + this.sheathDir.z * inserted;
             node.vx = this.sheathDir.x * feedSpeed;
             node.vy = this.sheathDir.y * feedSpeed;
             node.vz = this.sheathDir.z * feedSpeed;
@@ -309,7 +444,8 @@ export class GuidewireSolver {
     advance(command, dt, collisionTarget = null) {
         this.performanceStats = createPerformanceStats();
         const perfStart = nowMs();
-        const previous = this.rod.nodes.map(copyNodePosition);
+        const previous = snapshotNodePositions(this.rod.nodes, this._advancePreviousPositions);
+        this._advancePreviousPositions = previous;
         const nextProgress = clamp(
             this.tailProgress + command * this.advanceRate * dt,
             this.minInsert,
@@ -318,7 +454,11 @@ export class GuidewireSolver {
         const delta = nextProgress - this.tailProgress;
         this.tailProgress = nextProgress;
         this.lastAdvanceDelta = delta;
-        if (Math.abs(delta) > 1e-6) this.requestSettle();
+        if (Math.abs(delta) > 1e-6) {
+            this.requestSettle();
+            this.unsupportedBendRelaxArmed = true;
+            this.unsupportedBendRelaxFramesRemaining = 0;
+        }
         if (delta < -1e-6) {
             this.withdrawalRelaxFramesRemaining = Math.max(
                 this.withdrawalRelaxFramesRemaining,
@@ -345,19 +485,38 @@ export class GuidewireSolver {
     solve(dt, collisionTarget = null, { iterations = this.relaxationIterations, forceRelax = false } = {}) {
         const solveStart = nowMs();
         this.performanceStats.forceRelax = this.performanceStats.forceRelax || !!forceRelax;
-        const before = this.rod.nodes.map(copyNodePosition);
+        const before = snapshotNodePositions(this.rod.nodes, this._solvePreviousPositions);
+        this._solvePreviousPositions = before;
         this.contactPoints.length = 0;
         this.breachPoints.length = 0;
 
         this.constrainSheath();
         const advancing = this.lastAdvanceDelta > 1e-6;
         const recentlyWithdrawing = this.lastAdvanceDelta < -1e-6 || this.withdrawalRelaxFramesRemaining > 0;
-        const unsupportedFreeBend = !advancing && this.#hasUnsupportedFreeBend(collisionTarget);
+        let unsupportedFreeBend = false;
+        if (
+            !advancing &&
+            (this.unsupportedBendRelaxArmed || this.unsupportedBendRelaxFramesRemaining > 0)
+        ) {
+            unsupportedFreeBend = this.#hasUnsupportedFreeBend(collisionTarget);
+            if (unsupportedFreeBend && this.unsupportedBendRelaxArmed) {
+                this.unsupportedBendRelaxFramesRemaining = Math.max(
+                    this.unsupportedBendRelaxFramesRemaining,
+                    Math.max(1, Math.floor(this.unsupportedBendRelaxFrames))
+                );
+                this.unsupportedBendRelaxArmed = false;
+            } else if (!unsupportedFreeBend) {
+                this.unsupportedBendRelaxFramesRemaining = 0;
+                this.unsupportedBendRelaxArmed = true;
+            }
+        }
+        const unsupportedFreeBendRelaxing = unsupportedFreeBend &&
+            this.unsupportedBendRelaxFramesRemaining > 0;
         const shouldRelax = forceRelax ||
             Math.abs(this.lastAdvanceDelta) > 1e-6 ||
             this.settleFramesRemaining > 0 ||
             recentlyWithdrawing ||
-            unsupportedFreeBend;
+            unsupportedFreeBendRelaxing;
         if (!shouldRelax) {
             this.#zeroVelocities(before, dt, collisionTarget);
             this.performanceStats.solveMs += nowMs() - solveStart;
@@ -368,7 +527,7 @@ export class GuidewireSolver {
             this.#routeNudge();
             this.#limitTipBacktracking(collisionTarget);
         }
-        const shapeRelaxing = recentlyWithdrawing || unsupportedFreeBend;
+        const shapeRelaxing = recentlyWithdrawing || unsupportedFreeBendRelaxing;
         if (shapeRelaxing) {
             this.performanceStats.withdrawalRelaxed = this.#relaxWithdrawalShape(
                 collisionTarget,
@@ -436,6 +595,12 @@ export class GuidewireSolver {
         }
         if (this.lastAdvanceDelta >= -1e-6 && this.withdrawalRelaxFramesRemaining > 0) {
             this.withdrawalRelaxFramesRemaining--;
+        }
+        if (this.unsupportedBendRelaxFramesRemaining > 0) {
+            this.unsupportedBendRelaxFramesRemaining--;
+            if (this.unsupportedBendRelaxFramesRemaining <= 0 && !unsupportedFreeBend) {
+                this.unsupportedBendRelaxArmed = true;
+            }
         }
         this.performanceStats.solveMs += nowMs() - solveStart;
     }
@@ -512,7 +677,7 @@ export class GuidewireSolver {
                     if (this.#isInSheath(inserted)) continue;
 
                     const point = interpolatePosition(n0, n1, t);
-                    const contact = this.#pointContact(collider, point, clearance, true);
+                    const contact = this.#pointContact(collider, point, clearance, true, this._diagnosticContact);
                     const signedDistance = Number.isFinite(contact?.signedDistance)
                         ? contact.signedDistance
                         : null;
@@ -570,7 +735,7 @@ export class GuidewireSolver {
         let breach = lumen?.breach || false;
         const collider = collisionTarget?.meshCollider || collisionTarget?.lumenMeshCollider || null;
         if (collider?.pointContact && !this.#isInSheath(inserted)) {
-            const meshContact = this.#pointContact(collider, point, 0, true);
+            const meshContact = this.#pointContact(collider, point, 0, true, this._diagnosticContact);
             breach = breach || !!meshContact?.violation;
             contact = contact || (
                 !meshContact?.violation &&
@@ -587,7 +752,8 @@ export class GuidewireSolver {
         const invDt = 1 / Math.max(dt, 1e-6);
         const collider = this.#collisionCollider(collisionTarget);
 
-        for (let i = 0; i < this.rod.nodes.length; i++) {
+        const startIndex = this.#firstNodeOutsideSheathIndex();
+        for (let i = startIndex; i < this.rod.nodes.length; i++) {
             const node = this.rod.nodes[i];
             const inserted = this.insertedCoordinate(i);
             if (this.#isInSheath(inserted)) continue;
@@ -659,6 +825,23 @@ export class GuidewireSolver {
 
     #routeNudge(multiplier = 1) {
         if (this.routeBlend <= 0 || !this.lumenSampler) return;
+        const storage = this.rod.nodes.nodeStorage;
+        if (storage) {
+            const { x, y, z, pinned } = storage;
+            const startIndex = this.#firstNodeOutsideSheathIndex();
+            for (let i = startIndex; i < this.rod.nodes.length; i++) {
+                const inserted = this.insertedCoordinate(i);
+                if (this.#isInSheath(inserted)) continue;
+
+                const sample = this.routeSample(inserted);
+                const fade = smoothstep(this.sheathLength, this.sheathLength + this.segmentLength * 8, inserted);
+                const blend = this.routeBlend * multiplier * (0.35 + 0.65 * fade);
+                x[i] += (sample.point.x - x[i]) * blend;
+                y[i] += (sample.point.y - y[i]) * blend;
+                z[i] += (sample.point.z - z[i]) * blend;
+            }
+            return;
+        }
         for (let i = 0; i < this.rod.nodes.length; i++) {
             const node = this.rod.nodes[i];
             if (node.pinned) continue;
@@ -683,7 +866,7 @@ export class GuidewireSolver {
         const collider = this.#collisionCollider(collisionTarget);
         if (!collider?.pointContact) return false;
 
-        const contact = this.#pointContact(collider, node, this.meshClearance);
+        const contact = this.#pointContact(collider, node, this.meshClearance, false, this._supportContact);
         return !!contact?.violation || (
             Number.isFinite(contact?.signedDistance) &&
             contact.signedDistance <= this.meshClearance + this.unsupportedBendSupportBand
@@ -847,27 +1030,114 @@ export class GuidewireSolver {
         return applied;
     }
 
+    #preparePointBuffer(slot) {
+        const buffer = ensurePointBuffer(this[slot], this.rod.nodes.length);
+        this[slot] = buffer;
+        clearPointBuffer(buffer);
+        return buffer;
+    }
+
     #straightenInsideVessel(progress, collisionTarget = null) {
-        const corrections = new Array(this.rod.nodes.length);
+        const corrections = this.#preparePointBuffer('_straightenCorrections');
         const endpointBias = 0.35 + 0.65 * smoothstep(0, 1, progress);
         const collider = this.#collisionCollider(collisionTarget);
         const maxStep = this.segmentLength * 0.18;
-        const applyCorrection = (node, inserted, correction) => {
-            let move = correction;
-            if (collider?.pointContact && !this.#isInSheath(inserted)) {
-                move = this.#slideVectorAlongCollider(node, move, collider);
+        const correctionTarget = { x: 0, y: 0, z: 0 };
+        const storage = this.rod.nodes.nodeStorage;
+        if (storage) {
+            const { x, y, z, pinned } = storage;
+            const startIndex = this.#firstNodeOutsideSheathIndex();
+            const applyCorrection = (index, inserted, correction) => {
+                let moveX = correction.x;
+                let moveY = correction.y;
+                let moveZ = correction.z;
+                if (collider?.pointContact && !this.#isInSheath(inserted)) {
+                    const slidMove = this.#slideVectorAlongCollider(this.rod.nodes[index], correction, collider);
+                    moveX = slidMove.x;
+                    moveY = slidMove.y;
+                    moveZ = slidMove.z;
+                }
+                const length = Math.hypot(moveX, moveY, moveZ);
+                if (length > maxStep) {
+                    const scale = maxStep / length;
+                    moveX *= scale;
+                    moveY *= scale;
+                    moveZ *= scale;
+                }
+                correctionTarget.x = x[index] + moveX;
+                correctionTarget.y = y[index] + moveY;
+                correctionTarget.z = z[index] + moveZ;
+                return this.#projectPointInside(correctionTarget, inserted, collisionTarget, false);
+            };
+
+            for (let i = Math.max(1, startIndex); i < this.rod.nodes.length - 1; i++) {
+                if (pinned[i]) continue;
+
+                const inserted = this.insertedCoordinate(i);
+                const nearExit = 1 - smoothstep(this.sheathLength, this.sheathLength + this.segmentLength * 5, inserted);
+                const strength = this.straightening * endpointBias * (1 - nearExit * 0.45);
+                const correction = corrections[i];
+                correction.x = ((x[i - 1] + x[i + 1]) * 0.5 - x[i]) * strength;
+                correction.y = ((y[i - 1] + y[i + 1]) * 0.5 - y[i]) * strength;
+                correction.z = ((z[i - 1] + z[i + 1]) * 0.5 - z[i]) * strength;
+                correction.active = true;
             }
-            const length = Math.hypot(move.x, move.y, move.z);
+
+            for (let i = Math.max(1, startIndex); i < this.rod.nodes.length - 1; i++) {
+                const correction = corrections[i];
+                if (!correction.active || pinned[i]) continue;
+                const inserted = this.insertedCoordinate(i);
+                const constrained = applyCorrection(i, inserted, correction);
+                x[i] = constrained.x;
+                y[i] = constrained.y;
+                z[i] = constrained.z;
+            }
+
+            const spans = [2, 4, 8, 12];
+            for (const span of spans) {
+                const spanCorrections = this.#preparePointBuffer('_spanCorrections');
+                const spanStrength = this.straightening * 0.13 / Math.sqrt(span);
+                for (let i = Math.max(span, startIndex); i < this.rod.nodes.length - span; i++) {
+                    if (pinned[i]) continue;
+                    const correction = spanCorrections[i];
+                    correction.x = ((x[i - span] + x[i + span]) * 0.5 - x[i]) * spanStrength;
+                    correction.y = ((y[i - span] + y[i + span]) * 0.5 - y[i]) * spanStrength;
+                    correction.z = ((z[i - span] + z[i + span]) * 0.5 - z[i]) * spanStrength;
+                    correction.active = true;
+                }
+                for (let i = Math.max(span, startIndex); i < this.rod.nodes.length - span; i++) {
+                    const correction = spanCorrections[i];
+                    if (!correction.active || pinned[i]) continue;
+                    const inserted = this.insertedCoordinate(i);
+                    const constrained = applyCorrection(i, inserted, correction);
+                    x[i] = constrained.x;
+                    y[i] = constrained.y;
+                    z[i] = constrained.z;
+                }
+            }
+            return;
+        }
+        const applyCorrection = (node, inserted, correction) => {
+            let moveX = correction.x;
+            let moveY = correction.y;
+            let moveZ = correction.z;
+            if (collider?.pointContact && !this.#isInSheath(inserted)) {
+                const slidMove = this.#slideVectorAlongCollider(node, correction, collider);
+                moveX = slidMove.x;
+                moveY = slidMove.y;
+                moveZ = slidMove.z;
+            }
+            const length = Math.hypot(moveX, moveY, moveZ);
             if (length > maxStep) {
                 const scale = maxStep / length;
-                move = { x: move.x * scale, y: move.y * scale, z: move.z * scale };
+                moveX *= scale;
+                moveY *= scale;
+                moveZ *= scale;
             }
-            const target = {
-                x: node.x + move.x,
-                y: node.y + move.y,
-                z: node.z + move.z
-            };
-            return this.#projectPointInside(target, inserted, collisionTarget, false);
+            correctionTarget.x = node.x + moveX;
+            correctionTarget.y = node.y + moveY;
+            correctionTarget.z = node.z + moveZ;
+            return this.#projectPointInside(correctionTarget, inserted, collisionTarget, false);
         };
 
         for (let i = 1; i < this.rod.nodes.length - 1; i++) {
@@ -876,25 +1146,20 @@ export class GuidewireSolver {
 
             const prev = this.rod.nodes[i - 1];
             const next = this.rod.nodes[i + 1];
-            const midpoint = {
-                x: (prev.x + next.x) * 0.5,
-                y: (prev.y + next.y) * 0.5,
-                z: (prev.z + next.z) * 0.5
-            };
             const inserted = this.insertedCoordinate(i);
             const nearExit = 1 - smoothstep(this.sheathLength, this.sheathLength + this.segmentLength * 5, inserted);
             const strength = this.straightening * endpointBias * (1 - nearExit * 0.45);
-            corrections[i] = {
-                x: (midpoint.x - node.x) * strength,
-                y: (midpoint.y - node.y) * strength,
-                z: (midpoint.z - node.z) * strength
-            };
+            const correction = corrections[i];
+            correction.x = ((prev.x + next.x) * 0.5 - node.x) * strength;
+            correction.y = ((prev.y + next.y) * 0.5 - node.y) * strength;
+            correction.z = ((prev.z + next.z) * 0.5 - node.z) * strength;
+            correction.active = true;
         }
 
         for (let i = 1; i < this.rod.nodes.length - 1; i++) {
             const node = this.rod.nodes[i];
             const correction = corrections[i];
-            if (!correction || node.pinned) continue;
+            if (!correction.active || node.pinned) continue;
             const inserted = this.insertedCoordinate(i);
             const constrained = applyCorrection(node, inserted, correction);
             setNode(node, constrained);
@@ -902,28 +1167,23 @@ export class GuidewireSolver {
 
         const spans = [2, 4, 8, 12];
         for (const span of spans) {
-            const spanCorrections = new Array(this.rod.nodes.length);
+            const spanCorrections = this.#preparePointBuffer('_spanCorrections');
             const spanStrength = this.straightening * 0.13 / Math.sqrt(span);
             for (let i = span; i < this.rod.nodes.length - span; i++) {
                 const node = this.rod.nodes[i];
                 if (node.pinned) continue;
                 const prev = this.rod.nodes[i - span];
                 const next = this.rod.nodes[i + span];
-                const target = {
-                    x: (prev.x + next.x) * 0.5,
-                    y: (prev.y + next.y) * 0.5,
-                    z: (prev.z + next.z) * 0.5
-                };
-                spanCorrections[i] = {
-                    x: (target.x - node.x) * spanStrength,
-                    y: (target.y - node.y) * spanStrength,
-                    z: (target.z - node.z) * spanStrength
-                };
+                const correction = spanCorrections[i];
+                correction.x = ((prev.x + next.x) * 0.5 - node.x) * spanStrength;
+                correction.y = ((prev.y + next.y) * 0.5 - node.y) * spanStrength;
+                correction.z = ((prev.z + next.z) * 0.5 - node.z) * spanStrength;
+                correction.active = true;
             }
             for (let i = span; i < this.rod.nodes.length - span; i++) {
                 const node = this.rod.nodes[i];
                 const correction = spanCorrections[i];
-                if (!correction || node.pinned) continue;
+                if (!correction.active || node.pinned) continue;
                 const inserted = this.insertedCoordinate(i);
                 const constrained = applyCorrection(node, inserted, correction);
                 setNode(node, constrained);
@@ -933,7 +1193,7 @@ export class GuidewireSolver {
 
     #untangleFoldedSections() {
         if (this.foldUntangleStrength <= 0 || this.foldUntangleWindow <= 0) return;
-        const corrections = new Array(this.rod.nodes.length);
+        const corrections = this.#preparePointBuffer('_untangleCorrections');
         const threshold = clamp(this.foldAngle, 1, 179);
         const window = Math.max(1, Math.floor(this.foldUntangleWindow));
         const baseStrength = clamp(this.foldUntangleStrength, 0, 1);
@@ -957,17 +1217,20 @@ export class GuidewireSolver {
                 const strength = baseStrength * severity * falloff;
                 if (strength <= 0) continue;
                 const route = this.routeSample(targetInserted).point;
-                corrections[index] ??= { x: 0, y: 0, z: 0 };
-                corrections[index].x += (route.x - targetNode.x) * strength;
-                corrections[index].y += (route.y - targetNode.y) * strength;
-                corrections[index].z += (route.z - targetNode.z) * strength;
+                addCorrection(
+                    corrections,
+                    index,
+                    (route.x - targetNode.x) * strength,
+                    (route.y - targetNode.y) * strength,
+                    (route.z - targetNode.z) * strength
+                );
             }
         }
 
         for (let i = 1; i < this.rod.nodes.length - 1; i++) {
             const node = this.rod.nodes[i];
             const correction = corrections[i];
-            if (!correction || node.pinned) continue;
+            if (!correction.active || node.pinned) continue;
             addScaled(node, correction, 1);
         }
     }
@@ -985,7 +1248,7 @@ export class GuidewireSolver {
         const baseStrength = clamp(bendLimitStrength, 0, 1);
 
         for (let iter = 0; iter < bendLimitIterations; iter++) {
-            const corrections = new Array(this.rod.nodes.length);
+            const corrections = this.#preparePointBuffer('_bendLimitCorrections');
             for (let i = 1; i < this.rod.nodes.length - 1; i++) {
                 const node = this.rod.nodes[i];
                 if (node.pinned) continue;
@@ -1011,29 +1274,38 @@ export class GuidewireSolver {
                 if (chordLength < minChord) {
                     const spread = (minChord - chordLength) * 0.5 * strength;
                     if (!prev.pinned) {
-                        corrections[i - 1] ??= { x: 0, y: 0, z: 0 };
-                        corrections[i - 1].x -= direction.x * spread;
-                        corrections[i - 1].y -= direction.y * spread;
-                        corrections[i - 1].z -= direction.z * spread;
+                        addCorrection(
+                            corrections,
+                            i - 1,
+                            -direction.x * spread,
+                            -direction.y * spread,
+                            -direction.z * spread
+                        );
                     }
                     if (!next.pinned) {
-                        corrections[i + 1] ??= { x: 0, y: 0, z: 0 };
-                        corrections[i + 1].x += direction.x * spread;
-                        corrections[i + 1].y += direction.y * spread;
-                        corrections[i + 1].z += direction.z * spread;
+                        addCorrection(
+                            corrections,
+                            i + 1,
+                            direction.x * spread,
+                            direction.y * spread,
+                            direction.z * spread
+                        );
                     }
                 }
 
-                corrections[i] ??= { x: 0, y: 0, z: 0 };
-                corrections[i].x += ((prev.x + next.x) * 0.5 - node.x) * strength * centerPull;
-                corrections[i].y += ((prev.y + next.y) * 0.5 - node.y) * strength * centerPull;
-                corrections[i].z += ((prev.z + next.z) * 0.5 - node.z) * strength * centerPull;
+                addCorrection(
+                    corrections,
+                    i,
+                    ((prev.x + next.x) * 0.5 - node.x) * strength * centerPull,
+                    ((prev.y + next.y) * 0.5 - node.y) * strength * centerPull,
+                    ((prev.z + next.z) * 0.5 - node.z) * strength * centerPull
+                );
             }
 
             for (let i = 1; i < this.rod.nodes.length - 1; i++) {
                 const node = this.rod.nodes[i];
                 const correction = corrections[i];
-                if (!correction || node.pinned) continue;
+                if (!correction.active || node.pinned) continue;
                 addScaled(node, correction, 1);
             }
         }
@@ -1309,8 +1581,46 @@ export class GuidewireSolver {
     #solveLengths(iterations, collisionTarget = null, slideAgainstCollider = false) {
         const rest = this.segmentLength;
         const collider = slideAgainstCollider ? this.#collisionCollider(collisionTarget) : null;
+        const shouldSlide = !!collider?.pointContact;
+        const startIndex = this.#firstSegmentOutsideSheathIndex();
+        const storage = this.rod.nodes.nodeStorage;
+        if (!shouldSlide && storage) {
+            const { x, y, z, pinned } = storage;
+            for (let iter = 0; iter < iterations; iter++) {
+                for (let i = startIndex; i < this.rod.nodes.length - 1; i++) {
+                    const dx = x[i + 1] - x[i];
+                    const dy = y[i + 1] - y[i];
+                    const dz = z[i + 1] - z[i];
+                    const dist = Math.hypot(dx, dy, dz);
+                    if (dist < 1e-8) continue;
+
+                    const correction = (dist - rest) / dist;
+                    const w0 = pinned[i] ? 0 : 1;
+                    const w1 = pinned[i + 1] ? 0 : 1;
+                    const total = w0 + w1;
+                    if (total <= 0) continue;
+
+                    const c0 = w0 / total;
+                    const c1 = w1 / total;
+                    if (w0) {
+                        const scale = correction * c0;
+                        x[i] += dx * scale;
+                        y[i] += dy * scale;
+                        z[i] += dz * scale;
+                    }
+                    if (w1) {
+                        const scale = -correction * c1;
+                        x[i + 1] += dx * scale;
+                        y[i + 1] += dy * scale;
+                        z[i + 1] += dz * scale;
+                    }
+                }
+                this.constrainSheath();
+            }
+            return;
+        }
         for (let iter = 0; iter < iterations; iter++) {
-            for (let i = 0; i < this.rod.nodes.length - 1; i++) {
+            for (let i = startIndex; i < this.rod.nodes.length - 1; i++) {
                 const n0 = this.rod.nodes[i];
                 const n1 = this.rod.nodes[i + 1];
                 const dx = n1.x - n0.x;
@@ -1327,13 +1637,29 @@ export class GuidewireSolver {
 
                 const c0 = w0 / total;
                 const c1 = w1 / total;
+                if (!shouldSlide) {
+                    if (w0) {
+                        const scale = correction * c0;
+                        n0.x += dx * scale;
+                        n0.y += dy * scale;
+                        n0.z += dz * scale;
+                    }
+                    if (w1) {
+                        const scale = -correction * c1;
+                        n1.x += dx * scale;
+                        n1.y += dy * scale;
+                        n1.z += dz * scale;
+                    }
+                    continue;
+                }
+
                 if (w0) {
                     let move = {
                         x: dx * correction * c0,
                         y: dy * correction * c0,
                         z: dz * correction * c0
                     };
-                    if (collider?.pointContact && !this.#isInSheath(this.insertedCoordinate(i))) {
+                    if (!this.#isInSheath(this.insertedCoordinate(i))) {
                         move = this.#slideVectorAlongCollider(n0, move, collider);
                     }
                     n0.x += move.x;
@@ -1346,7 +1672,7 @@ export class GuidewireSolver {
                         y: -dy * correction * c1,
                         z: -dz * correction * c1
                     };
-                    if (collider?.pointContact && !this.#isInSheath(this.insertedCoordinate(i + 1))) {
+                    if (!this.#isInSheath(this.insertedCoordinate(i + 1))) {
                         move = this.#slideVectorAlongCollider(n1, move, collider);
                     }
                     n1.x += move.x;
@@ -1368,7 +1694,27 @@ export class GuidewireSolver {
     }
 
     #projectNodesInside(collisionTarget, recordContacts) {
-        for (let i = 0; i < this.rod.nodes.length; i++) {
+        const startIndex = this.#firstNodeOutsideSheathIndex();
+        const storage = this.rod.nodes.nodeStorage;
+        if (storage) {
+            const { x, y, z, pinned } = storage;
+            const point = this._projectNodePoint;
+            for (let i = startIndex; i < this.rod.nodes.length; i++) {
+                if (pinned[i]) continue;
+                const inserted = this.insertedCoordinate(i);
+                if (this.#isInSheath(inserted)) continue;
+                this.performanceStats.nodeProjectionCount++;
+                point.x = x[i];
+                point.y = y[i];
+                point.z = z[i];
+                const projected = this.#projectPointInside(point, inserted, collisionTarget, recordContacts);
+                x[i] = projected.x;
+                y[i] = projected.y;
+                z[i] = projected.z;
+            }
+            return;
+        }
+        for (let i = startIndex; i < this.rod.nodes.length; i++) {
             const node = this.rod.nodes[i];
             if (node.pinned) continue;
             const inserted = this.insertedCoordinate(i);
@@ -1380,7 +1726,55 @@ export class GuidewireSolver {
     }
 
     #projectSegmentsInside(collisionTarget, recordContacts) {
-        for (let i = 0; i < this.rod.nodes.length - 1; i++) {
+        const point = { x: 0, y: 0, z: 0 };
+        const maxCorrection = this.segmentLength * this.maxSegmentProjectionStep;
+        const startIndex = this.#firstSegmentOutsideSheathIndex();
+        const storage = this.rod.nodes.nodeStorage;
+        if (storage) {
+            const { x, y, z, pinned } = storage;
+            for (let i = startIndex; i < this.rod.nodes.length - 1; i++) {
+                if (pinned[i] && pinned[i + 1]) continue;
+
+                for (const t of this.segmentSamples) {
+                    const inserted = this.insertedCoordinate(i + t);
+                    if (this.#isInSheath(inserted)) continue;
+                    this.performanceStats.segmentSampleCount++;
+                    const w0 = pinned[i] ? 0 : 1 - t;
+                    const w1 = pinned[i + 1] ? 0 : t;
+                    point.x = x[i] * (1 - t) + x[i + 1] * t;
+                    point.y = y[i] * (1 - t) + y[i + 1] * t;
+                    point.z = z[i] * (1 - t) + z[i + 1] * t;
+                    const target = this.#projectPointInside(point, inserted, collisionTarget, recordContacts);
+                    let correctionX = (target.x - point.x) * this.segmentProjectionBlend;
+                    let correctionY = (target.y - point.y) * this.segmentProjectionBlend;
+                    let correctionZ = (target.z - point.z) * this.segmentProjectionBlend;
+                    const correctionLength = Math.hypot(correctionX, correctionY, correctionZ);
+                    if (correctionLength > maxCorrection) {
+                        const scale = maxCorrection / correctionLength;
+                        correctionX *= scale;
+                        correctionY *= scale;
+                        correctionZ *= scale;
+                    }
+                    const denom = w0 * w0 + w1 * w1;
+                    if (denom <= 1e-8) continue;
+                    this.performanceStats.segmentProjectionCount++;
+                    if (w0) {
+                        const scale = w0 / denom;
+                        x[i] += correctionX * scale;
+                        y[i] += correctionY * scale;
+                        z[i] += correctionZ * scale;
+                    }
+                    if (w1) {
+                        const scale = w1 / denom;
+                        x[i + 1] += correctionX * scale;
+                        y[i + 1] += correctionY * scale;
+                        z[i + 1] += correctionZ * scale;
+                    }
+                }
+            }
+            return;
+        }
+        for (let i = startIndex; i < this.rod.nodes.length - 1; i++) {
             const n0 = this.rod.nodes[i];
             const n1 = this.rod.nodes[i + 1];
             if (n0.pinned && n1.pinned) continue;
@@ -1389,28 +1783,37 @@ export class GuidewireSolver {
                 const inserted = this.insertedCoordinate(i + t);
                 if (this.#isInSheath(inserted)) continue;
                 this.performanceStats.segmentSampleCount++;
-                const point = interpolatePosition(n0, n1, t);
-                const target = this.#projectPointInside(point, inserted, collisionTarget, recordContacts);
-                const correction = {
-                    x: (target.x - point.x) * this.segmentProjectionBlend,
-                    y: (target.y - point.y) * this.segmentProjectionBlend,
-                    z: (target.z - point.z) * this.segmentProjectionBlend
-                };
-                const correctionLength = Math.hypot(correction.x, correction.y, correction.z);
-                const maxCorrection = this.segmentLength * this.maxSegmentProjectionStep;
-                if (correctionLength > maxCorrection) {
-                    const scale = maxCorrection / correctionLength;
-                    correction.x *= scale;
-                    correction.y *= scale;
-                    correction.z *= scale;
-                }
                 const w0 = n0.pinned ? 0 : 1 - t;
                 const w1 = n1.pinned ? 0 : t;
+                point.x = n0.x * (1 - t) + n1.x * t;
+                point.y = n0.y * (1 - t) + n1.y * t;
+                point.z = n0.z * (1 - t) + n1.z * t;
+                const target = this.#projectPointInside(point, inserted, collisionTarget, recordContacts);
+                let correctionX = (target.x - point.x) * this.segmentProjectionBlend;
+                let correctionY = (target.y - point.y) * this.segmentProjectionBlend;
+                let correctionZ = (target.z - point.z) * this.segmentProjectionBlend;
+                const correctionLength = Math.hypot(correctionX, correctionY, correctionZ);
+                if (correctionLength > maxCorrection) {
+                    const scale = maxCorrection / correctionLength;
+                    correctionX *= scale;
+                    correctionY *= scale;
+                    correctionZ *= scale;
+                }
                 const denom = w0 * w0 + w1 * w1;
                 if (denom <= 1e-8) continue;
                 this.performanceStats.segmentProjectionCount++;
-                if (w0) addScaled(n0, correction, w0 / denom);
-                if (w1) addScaled(n1, correction, w1 / denom);
+                if (w0) {
+                    const scale = w0 / denom;
+                    n0.x += correctionX * scale;
+                    n0.y += correctionY * scale;
+                    n0.z += correctionZ * scale;
+                }
+                if (w1) {
+                    const scale = w1 / denom;
+                    n1.x += correctionX * scale;
+                    n1.y += correctionY * scale;
+                    n1.z += correctionZ * scale;
+                }
             }
         }
     }
@@ -1418,7 +1821,7 @@ export class GuidewireSolver {
     #projectPointInside(point, inserted, collisionTarget, recordContacts) {
         const collider = collisionTarget?.meshCollider || collisionTarget?.lumenMeshCollider || null;
         if (collider?.pointContact && !this.#isInSheath(inserted)) {
-            let projected = { x: point.x, y: point.y, z: point.z };
+            let projected = point;
             if (this.lumenSampler) {
                 const lumenState = this.#lumenConstraint(point, inserted);
                 projected = lumenState.projected;
@@ -1427,7 +1830,7 @@ export class GuidewireSolver {
                     else if (lumenState.radialMargin <= DEFAULT_CONTACT_BAND) this.#pushLimited(this.contactPoints, point);
                 }
             }
-            const contact = this.#pointContact(collider, projected, this.meshClearance);
+            const contact = this.#pointContact(collider, projected, this.meshClearance, false, this._projectContact);
             if (contact?.violation && contact.target) {
                 if (recordContacts) {
                     if (Number.isFinite(contact.signedDistance) && contact.signedDistance < 0) {
@@ -1450,13 +1853,13 @@ export class GuidewireSolver {
         return collisionTarget?.meshCollider || collisionTarget?.lumenMeshCollider || null;
     }
 
-    #pointContact(collider, point, clearance, diagnostic = false) {
+    #pointContact(collider, point, clearance, diagnostic = false, out = null) {
         if (diagnostic) {
             this.performanceStats.diagnosticPointContactCount++;
         } else {
             this.performanceStats.pointContactCount++;
         }
-        return collider.pointContact(point, clearance);
+        return collider.pointContact(point, clearance, out);
     }
 
     #slideVectorAlongCollider(point, vector, collider) {
@@ -1467,8 +1870,8 @@ export class GuidewireSolver {
             y: point.y + vector.y,
             z: point.z + vector.z
         };
-        const pointContact = this.#pointContact(collider, point, this.meshClearance);
-        const targetContact = this.#pointContact(collider, target, this.meshClearance);
+        const pointContact = this.#pointContact(collider, point, this.meshClearance, false, this._slidePointContact);
+        const targetContact = this.#pointContact(collider, target, this.meshClearance, false, this._slideTargetContact);
         const pointNearWall = pointContact?.violation || (
             Number.isFinite(pointContact?.signedDistance) &&
             pointContact.signedDistance <= this.meshClearance + DEFAULT_CONTACT_BAND
@@ -1504,7 +1907,7 @@ export class GuidewireSolver {
     }
 
     #projectToLumen(point, inserted, recordContacts) {
-        if (!this.lumenSampler) return { x: point.x, y: point.y, z: point.z };
+        if (!this.lumenSampler) return point;
         const state = this.#lumenConstraint(point, inserted);
         if (recordContacts) {
             if (state.breach) this.#pushLimited(this.breachPoints, point);
@@ -1516,14 +1919,18 @@ export class GuidewireSolver {
     #lumenConstraint(point, inserted) {
         const sample = this.routeSample(inserted);
         const radius = Math.max(0.5, (sample.radius || 1) - this.lumenClearance);
-        const tangent = normalizeVector(sample.tangent, this.sheathDir);
+        const tangentSource = sample.tangent || this.sheathDir;
+        const tangentLength = Math.hypot(tangentSource.x, tangentSource.y, tangentSource.z);
+        const tangentX = tangentLength < 1e-8 ? this.sheathDir.x : tangentSource.x / tangentLength;
+        const tangentY = tangentLength < 1e-8 ? this.sheathDir.y : tangentSource.y / tangentLength;
+        const tangentZ = tangentLength < 1e-8 ? this.sheathDir.z : tangentSource.z / tangentLength;
         const dx = point.x - sample.point.x;
         const dy = point.y - sample.point.y;
         const dz = point.z - sample.point.z;
-        let axialOffset = dx * tangent.x + dy * tangent.y + dz * tangent.z;
-        let lateralX = dx - tangent.x * axialOffset;
-        let lateralY = dy - tangent.y * axialOffset;
-        let lateralZ = dz - tangent.z * axialOffset;
+        let axialOffset = dx * tangentX + dy * tangentY + dz * tangentZ;
+        let lateralX = dx - tangentX * axialOffset;
+        let lateralY = dy - tangentY * axialOffset;
+        let lateralZ = dz - tangentZ * axialOffset;
         let lateralLength = Math.hypot(lateralX, lateralY, lateralZ);
         const axialWindow = Math.max(this.segmentLength * 0.5, this.segmentLength * this.axialWindowScale);
         const breach = lateralLength > radius + 1e-4;
@@ -1537,33 +1944,47 @@ export class GuidewireSolver {
         }
         axialOffset = clamp(axialOffset, -axialWindow, axialWindow);
 
-        return {
-            projected: {
-                x: sample.point.x + tangent.x * axialOffset + lateralX,
-                y: sample.point.y + tangent.y * axialOffset + lateralY,
-                z: sample.point.z + tangent.z * axialOffset + lateralZ
-            },
-            radialMargin: radius - lateralLength,
-            axialOffset,
-            axialWindow,
-            breach
-        };
+        const state = this._lumenConstraintState;
+        state.projected.x = sample.point.x + tangentX * axialOffset + lateralX;
+        state.projected.y = sample.point.y + tangentY * axialOffset + lateralY;
+        state.projected.z = sample.point.z + tangentZ * axialOffset + lateralZ;
+        state.radialMargin = radius - lateralLength;
+        state.axialOffset = axialOffset;
+        state.axialWindow = axialWindow;
+        state.breach = breach;
+        return state;
     }
 
     #zeroVelocities(before, dt, collisionTarget = null) {
         const invDt = 1 / Math.max(dt, 1e-6);
         const collider = collisionTarget?.meshCollider || collisionTarget?.lumenMeshCollider || null;
+        const storage = this.rod.nodes.nodeStorage;
+        if (storage && !collider?.pointContact) {
+            const { x, y, z, vx, vy, vz } = storage;
+            for (let i = 0; i < this.rod.nodes.length; i++) {
+                const dx = x[i] - before[i].x;
+                const dy = y[i] - before[i].y;
+                const dz = z[i] - before[i].z;
+                const scale = dx * dx + dy * dy + dz * dz > 0.0004 ? 0.08 : 0;
+                vx[i] = dx * invDt * scale;
+                vy[i] = dy * invDt * scale;
+                vz[i] = dz * invDt * scale;
+            }
+            return;
+        }
         for (let i = 0; i < this.rod.nodes.length; i++) {
             const node = this.rod.nodes[i];
-            const moved = nodeDistance(node, before[i]);
-            const scale = moved > 0.02 ? 0.08 : 0;
-            let vx = (node.x - before[i].x) * invDt * scale;
-            let vy = (node.y - before[i].y) * invDt * scale;
-            let vz = (node.z - before[i].z) * invDt * scale;
+            const dx = node.x - before[i].x;
+            const dy = node.y - before[i].y;
+            const dz = node.z - before[i].z;
+            const scale = dx * dx + dy * dy + dz * dz > 0.0004 ? 0.08 : 0;
+            let vx = dx * invDt * scale;
+            let vy = dy * invDt * scale;
+            let vz = dz * invDt * scale;
 
             const inserted = this.insertedCoordinate(i);
             if (collider?.pointContact && !this.#isInSheath(inserted)) {
-                const contact = this.#pointContact(collider, node, this.meshClearance);
+                const contact = this.#pointContact(collider, node, this.meshClearance, false, this._zeroVelocityContact);
                 const normal = contact?.normal;
                 const nearWall = contact?.violation || (
                     Number.isFinite(contact?.signedDistance) &&


### PR DESCRIPTION
## Summary
- Optimize guidewire/lumen collision queries with reusable query buffers and cached slice interval lookup.
- Move rod node state into typed arrays while preserving the existing `rod.nodes[i]` API through node views.
- Add direct typed-array paths in guidewire solver hot loops for sheath constraints, length solving, projection, route nudging, straightening, and velocity damping.

## Validation
- `node tests/elasticRod.test.js`
- `node tests/guidewireSolver.test.js`
- `npm test`

Guidewire regression metrics stayed stable: `breaches 0`, unchanged segment-error metrics for insertion, withdrawal, and max insertion.