### PR TITLE
Improve cine playback and roadmap creation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Endovascular Trainer</title>
-    <link rel="stylesheet" href="style.css?v=20260804controlwidth1">
+    <link rel="stylesheet" href="style.css?v=20260812dual-range1">
 </head>
 <body>
 <div id="loadingScreen" class="loading-screen" role="status" aria-live="polite" aria-label="Loading simulator">
@@ -30,6 +30,18 @@
     <div id="imagingModeBadge" class="imaging-mode-badge" role="status" aria-live="polite" hidden></div>
     <div id="dsaCineControls" class="dsa-cine-controls" hidden>
         <span id="dsaCineStatus">CINE</span>
+        <label class="dsa-cine-frame-control">Frame
+            <input id="dsaCineFrame" type="range" min="0" max="0" step="1" value="0">
+        </label>
+        <label class="dsa-cine-speed-control">Speed
+            <select id="dsaCineSpeed">
+                <option value="0.25">0.25×</option>
+                <option value="0.5">0.5×</option>
+                <option value="1" selected>1×</option>
+                <option value="1.5">1.5×</option>
+                <option value="2">2×</option>
+            </select>
+        </label>
         <button id="dsaCinePlayPause" type="button">Pause</button>
         <button id="dsaCineStop" type="button">Return to live</button>
     </div>
@@ -219,6 +231,17 @@
                             </label>
                             <button id="useBestDsaFrame" type="button" disabled>Use best-filled frame</button>
                             <output id="dsaFrameInfo">Hold R to record a sequence</output>
+                            <div class="dsa-roadmap-range">
+                                <div class="dsa-roadmap-range-selector">
+                                    <span>Roadmap frame range</span>
+                                    <div id="dsaRangeSlider" class="dsa-range-slider disabled">
+                                        <input id="dsaRangeStart" aria-label="Range start" type="range" min="0" max="0" step="1" value="0" disabled>
+                                        <input id="dsaRangeEnd" aria-label="Range end" type="range" min="0" max="0" step="1" value="0" disabled>
+                                    </div>
+                                </div>
+                                <button id="buildRoadmapRange" type="button" disabled>Build range roadmap</button>
+                                <output id="dsaRangeInfo">Select a saved angiography</output>
+                            </div>
                         </div>
                         <div class="dsa-gallery-heading">
                             <span>Recorded DSA gallery</span>
@@ -228,11 +251,19 @@
                             <div class="dsa-gallery-empty">Recorded angiography will appear here</div>
                         </div>
                         <label class="parameter-label dsa-roadmap-opacity">Roadmap opacity
-                            <input id="roadmapOpacity" type="range" min="0" max="100" step="1" value="72">
+                            <input id="roadmapOpacity" type="range" min="0" max="100" step="1" value="30">
                             <span></span>
                         </label>
                         <label class="parameter-label dsa-roadmap-background">Roadmap background
                             <input id="roadmapBackground" type="range" min="0" max="100" step="1" value="100">
+                            <span></span>
+                        </label>
+                        <label class="parameter-label dsa-roadmap-edge-enhancement">Roadmap edge enhancement
+                            <input id="roadmapEdgeEnhancement" type="range" min="0" max="100" step="1" value="45">
+                            <span></span>
+                        </label>
+                        <label class="parameter-label dsa-roadmap-edge-darkness">Roadmap edge darkness
+                            <input id="roadmapEdgeDarkness" type="range" min="0" max="100" step="1" value="25">
                             <span></span>
                         </label>
                         <label class="parameter-label dsa-gain-control">DSA gain

--- a/src/imaging/dsaFrameComposite.js
+++ b/src/imaging/dsaFrameComposite.js
@@ -1,0 +1,22 @@
+/**
+ * Builds a minimum-intensity projection from grayscale DSA frames. DSA stores
+ * opacified vessels as dark pixels, so the minimum at each detector pixel
+ * preserves the strongest vessel signal seen anywhere in the selected range.
+ */
+export function composeDsaFrameRangeRedChannels(redChannels) {
+    if (!Array.isArray(redChannels) || !redChannels.length) return null;
+    const first = redChannels[0];
+    if (!first?.length) return null;
+    const composite = new Uint8Array(first);
+    for (let frameIndex = 1; frameIndex < redChannels.length; frameIndex++) {
+        const channel = redChannels[frameIndex];
+        if (!channel || channel.length !== composite.length) return null;
+        for (let pixelIndex = 0; pixelIndex < composite.length; pixelIndex++) {
+            composite[pixelIndex] = Math.min(
+                composite[pixelIndex],
+                channel[pixelIndex]
+            );
+        }
+    }
+    return composite;
+}

--- a/src/imaging/dsaRoadmapState.js
+++ b/src/imaging/dsaRoadmapState.js
@@ -169,11 +169,15 @@ export class DsaRoadmapState {
         this.sequences = [];
         this.selectedSequenceId = null;
         this.selectedFrameIndex = null;
+        this.selectedRangeStartIndex = null;
+        this.selectedRangeEndIndex = null;
+        this.roadmapCompositeActive = false;
         this.cinePlaying = false;
         this.cineSequenceId = null;
         this.cineFrameIndex = null;
         this.cinePlaybackStartedAtMs = null;
         this.cineElapsedMs = 0;
+        this.cinePlaybackRate = 1;
         this.nextSequenceId = 1;
         this._roadmapWasEnabledBeforeRecording = false;
         this.status = 'Hold R to record a DSA sequence';
@@ -278,6 +282,9 @@ export class DsaRoadmapState {
         this.dsaEnabled = false;
         this.selectedSequenceId = null;
         this.selectedFrameIndex = null;
+        this.selectedRangeStartIndex = null;
+        this.selectedRangeEndIndex = null;
+        this.roadmapCompositeActive = false;
         this.status = 'Current DSA frame selected as roadmap';
         return true;
     }
@@ -440,6 +447,9 @@ export class DsaRoadmapState {
         sequence.selectedFrameIndex = index;
         this.selectedSequenceId = sequence.id;
         this.selectedFrameIndex = index;
+        this.selectedRangeStartIndex = index;
+        this.selectedRangeEndIndex = index;
+        this.roadmapCompositeActive = false;
         this.roadmapValid = true;
         this.roadmapEnabled = true;
         this.dsaEnabled = false;
@@ -451,6 +461,48 @@ export class DsaRoadmapState {
             frameIndex: index,
             storageKey: frame.storageKey,
             automatic
+        });
+    }
+
+    selectRoadmapRange(sequenceId, startFrameIndex, endFrameIndex) {
+        const sequence = this._sequence(sequenceId);
+        if (!sequence?.complete || !sequence.frames.length) {
+            this.status = 'The selected DSA frame range is unavailable';
+            return captureResult(false, this.status);
+        }
+        const lastIndex = sequence.frames.length - 1;
+        const requestedStart = Math.round(Number(startFrameIndex));
+        const requestedEnd = Math.round(Number(endFrameIndex));
+        if (!Number.isFinite(requestedStart) || !Number.isFinite(requestedEnd)) {
+            this.status = 'Select a valid DSA frame range';
+            return captureResult(false, this.status);
+        }
+        const startIndex = Math.max(
+            0,
+            Math.min(lastIndex, Math.min(requestedStart, requestedEnd))
+        );
+        const endIndex = Math.max(
+            0,
+            Math.min(lastIndex, Math.max(requestedStart, requestedEnd))
+        );
+        this.selectedSequenceId = sequence.id;
+        this.selectedFrameIndex = null;
+        this.selectedRangeStartIndex = startIndex;
+        this.selectedRangeEndIndex = endIndex;
+        this.roadmapCompositeActive = true;
+        this.roadmapValid = true;
+        this.roadmapEnabled = true;
+        this.dsaEnabled = false;
+        const frameCount = endIndex - startIndex + 1;
+        this.status = `DSA ${sequence.id} · frames ${startIndex + 1}–${endIndex + 1} combined into roadmap`;
+        return captureResult(true, '', {
+            sequenceId: sequence.id,
+            startFrameIndex: startIndex,
+            endFrameIndex: endIndex,
+            frameCount,
+            storageKeys: sequence.frames
+                .slice(startIndex, endIndex + 1)
+                .map(frame => frame.storageKey)
         });
     }
 
@@ -485,7 +537,7 @@ export class DsaRoadmapState {
         }
         this.cineSequenceId = sequence.id;
         this.cinePlaying = true;
-        this.cinePlaybackStartedAtMs = nowMs - this.cineElapsedMs;
+        this.cinePlaybackStartedAtMs = nowMs;
         this.status = `Playing DSA ${sequence.id} as cine`;
         return captureResult(true, '', {
             sequenceId: sequence.id,
@@ -505,6 +557,40 @@ export class DsaRoadmapState {
             sequenceId: this.cineSequenceId,
             frameIndex: this.cineFrameIndex
         });
+    }
+
+    seekCineFrame(frameIndex, { nowMs = Date.now() } = {}) {
+        const sequence = this._sequence(this.cineSequenceId);
+        const index = Math.round(Number(frameIndex));
+        const frame = sequence?.frames[index];
+        if (!sequence?.complete || !frame) {
+            this.status = 'The selected cine frame is unavailable';
+            return captureResult(false, this.status);
+        }
+        const timing = this._cineTiming(sequence);
+        this.cineFrameIndex = index;
+        this.cineElapsedMs = timing.frameOffsetsMs[index] || 0;
+        if (this.cinePlaying) this.cinePlaybackStartedAtMs = nowMs;
+        this.status = `DSA ${sequence.id} cine · frame ${index + 1}/${sequence.frames.length}`;
+        return captureResult(true, '', {
+            sequenceId: sequence.id,
+            frameIndex: index,
+            durationMs: timing.durationMs
+        });
+    }
+
+    setCinePlaybackRate(playbackRate, { nowMs = Date.now() } = {}) {
+        const rate = Number(playbackRate);
+        if (!Number.isFinite(rate) || rate < 0.1 || rate > 4) {
+            return captureResult(false, 'Cine playback speed must be between 0.1× and 4×');
+        }
+        if (this.cinePlaying) this.advanceCine({ nowMs });
+        this.cinePlaybackRate = rate;
+        if (this.cinePlaying) this.cinePlaybackStartedAtMs = nowMs;
+        this.status = this.cineSequenceId === null
+            ? `Cine speed set to ${rate}×`
+            : `DSA ${this.cineSequenceId} cine · ${rate}×`;
+        return captureResult(true, '', { playbackRate: rate });
     }
 
     toggleCine(sequenceId = this.cineSequenceId, { nowMs = Date.now() } = {}) {
@@ -547,9 +633,14 @@ export class DsaRoadmapState {
         }
         const timing = this._cineTiming(sequence);
         const elapsed = timing.durationMs > 0
-            ? Math.max(0, nowMs - this.cinePlaybackStartedAtMs) % timing.durationMs
+            ? (
+                this.cineElapsedMs +
+                Math.max(0, nowMs - this.cinePlaybackStartedAtMs) *
+                    this.cinePlaybackRate
+            ) % timing.durationMs
             : 0;
         this.cineElapsedMs = elapsed;
+        this.cinePlaybackStartedAtMs = nowMs;
         let frameIndex = 0;
         for (let index = 1; index < timing.frameOffsetsMs.length; index++) {
             if (timing.frameOffsetsMs[index] > elapsed) break;
@@ -586,6 +677,9 @@ export class DsaRoadmapState {
         this.roadmapEnabled = false;
         this.selectedSequenceId = null;
         this.selectedFrameIndex = null;
+        this.selectedRangeStartIndex = null;
+        this.selectedRangeEndIndex = null;
+        this.roadmapCompositeActive = false;
         this.status = this.dsaEnabled
             ? 'DSA active · roadmap cleared'
             : this.sequences.some(sequence => sequence.complete)
@@ -629,6 +723,9 @@ export class DsaRoadmapState {
             this.roadmapEnabled = false;
             this.selectedSequenceId = null;
             this.selectedFrameIndex = null;
+            this.selectedRangeStartIndex = null;
+            this.selectedRangeEndIndex = null;
+            this.roadmapCompositeActive = false;
         }
         this.status = reason;
     }
@@ -648,9 +745,13 @@ export class DsaRoadmapState {
             recordingSequenceId: this.recordingSequenceId,
             selectedSequenceId: this.selectedSequenceId,
             selectedFrameIndex: this.selectedFrameIndex,
+            selectedRangeStartIndex: this.selectedRangeStartIndex,
+            selectedRangeEndIndex: this.selectedRangeEndIndex,
+            roadmapCompositeActive: this.roadmapCompositeActive,
             cinePlaying: this.cinePlaying,
             cineSequenceId: this.cineSequenceId,
             cineFrameIndex: this.cineFrameIndex,
+            cinePlaybackRate: this.cinePlaybackRate,
             maxSequences: this.maxSequences,
             maxFramesPerSequence: this.maxFramesPerSequence,
             sequences: this.sequences.map(cloneSequence),
@@ -717,6 +818,9 @@ export class DsaRoadmapState {
             if (removed.id === this.selectedSequenceId) {
                 this.selectedSequenceId = null;
                 this.selectedFrameIndex = null;
+                this.selectedRangeStartIndex = null;
+                this.selectedRangeEndIndex = null;
+                this.roadmapCompositeActive = false;
                 this.roadmapValid = false;
                 this.roadmapEnabled = false;
             }

--- a/src/shaders/displayShader.js
+++ b/src/shaders/displayShader.js
@@ -48,6 +48,8 @@ uniform float contrastGain;
 uniform float dsaGain;
 uniform float roadmapOpacity;
 uniform float roadmapBackgroundVisibility;
+uniform float roadmapEdgeEnhancement;
+uniform float roadmapEdgeDarkness;
 varying vec2 vUv;
 
 float saturate(float value) {
@@ -237,6 +239,29 @@ float edgeFactor(vec2 uv) {
     float gy = -tl - 2.0*t - tr + bl + 2.0*b + br;
     return length(vec2(gx, gy));
 }
+
+float roadmapVesselAt(vec2 uv) {
+    float storedRoadmapLuma = texture2D(roadmapTexture, uv).r /
+        max(0.001, gray.r * 0.992);
+    float roadmapDifference = max(0.0, 0.94 - storedRoadmapLuma);
+    return smoothstep(0.032, 0.34, roadmapDifference);
+}
+
+float roadmapEdgeAt(vec2 uv) {
+    vec2 texel = 1.0 / resolution;
+    float tl = roadmapVesselAt(uv + texel * vec2(-1.0, -1.0));
+    float t  = roadmapVesselAt(uv + texel * vec2(0.0, -1.0));
+    float tr = roadmapVesselAt(uv + texel * vec2(1.0, -1.0));
+    float l  = roadmapVesselAt(uv + texel * vec2(-1.0, 0.0));
+    float r  = roadmapVesselAt(uv + texel * vec2(1.0, 0.0));
+    float bl = roadmapVesselAt(uv + texel * vec2(-1.0, 1.0));
+    float b  = roadmapVesselAt(uv + texel * vec2(0.0, 1.0));
+    float br = roadmapVesselAt(uv + texel * vec2(1.0, 1.0));
+    float gx = -tl - 2.0 * l - bl + tr + 2.0 * r + br;
+    float gy = -tl - 2.0 * t - tr + bl + 2.0 * b + br;
+    return smoothstep(0.08, 1.4, length(vec2(gx, gy)));
+}
+
 void main() {
     vec4 tex = texture2D(uTexture, vUv);
     if (fluoroscopy) {
@@ -302,14 +327,13 @@ void main() {
         } else if (roadmapEnabled && roadmapValid) {
             // A roadmap target stores a DSA frame (light background, dark
             // opacified vessels). Convert its darkness to a fixed vessel mask
-            // and superimpose it on the current live fluoroscopy.
-            float storedRoadmapLuma = texture2D(roadmapTexture, vUv).r /
-                max(0.001, gray.r * 0.992);
+            // and use that mask to brighten the corresponding vessels in the
+            // current live fluoroscopy.
             // Reject subtraction noise before turning the saved DSA frame into
             // a persistent vessel stencil. True iodine-filled vessels are much
             // darker than the 2-3% detector mottle around the DSA background.
-            float roadmapDifference = max(0.0, 0.94 - storedRoadmapLuma);
-            float roadmapVessel = smoothstep(0.032, 0.34, roadmapDifference) * beamMask;
+            float roadmapVessel = roadmapVesselAt(vUv) * beamMask;
+            float roadmapEdge = roadmapEdgeAt(vUv) * beamMask;
             // Background visibility is independent from the vessel overlay.
             // At 0% retain the bright subtraction field inside the beam; at
             // 100% retain the full live fluoroscopic anatomy.
@@ -319,13 +343,25 @@ void main() {
                 luma,
                 saturate(roadmapBackgroundVisibility)
             );
-            float roadmappedLuma = min(
+            float roadmapLayer = mix(
                 visibleRoadmapBackground,
-                1.0 - roadmapVessel * 0.94
+                1.0,
+                roadmapVessel
+            );
+            // A Sobel contour sharpens the saved vessel mask. Its color can be
+            // pulled slightly below the live background to create a subtle,
+            // adjustable dark border around the bright roadmap vessel.
+            float roadmapEdgeTarget = visibleRoadmapBackground * (
+                1.0 - saturate(roadmapEdgeDarkness) * 0.7
+            );
+            roadmapLayer = mix(
+                roadmapLayer,
+                roadmapEdgeTarget,
+                roadmapEdge * saturate(roadmapEdgeEnhancement)
             );
             luma = mix(
                 visibleRoadmapBackground,
-                roadmappedLuma,
+                roadmapLayer,
                 saturate(roadmapOpacity)
             );
         }

--- a/src/simulator.js
+++ b/src/simulator.js
@@ -27,6 +27,7 @@ import {
     dsaArchiveDimensions,
     dsaScoreDimensions
 } from './imaging/dsaCaptureSizing.js';
+import { composeDsaFrameRangeRedChannels } from './imaging/dsaFrameComposite.js';
 import {
     GUIDEWIRE_RADIUS_MM,
     GUIDEWIRE_RENDER_RADIUS_MM,
@@ -198,6 +199,8 @@ let dsaContrastScoreReadback = new Uint8Array(
 );
 const dsaSequenceFrameTextures = new Map();
 const dsaSequencePreviewUrls = new Map();
+let dsaCompositeRoadmapTexture = null;
+let dsaCompositeRoadmapKey = '';
 let previousTarget = accumulateTarget1;
 let currentTarget = accumulateTarget2;
 const dsaRoadmapState = new DsaRoadmapState();
@@ -377,8 +380,10 @@ const displayMaterial = new THREE.ShaderMaterial({
         contrastOpacity: { value: 1.0 },
         contrastGain: { value: 5.0 },
         dsaGain: { value: 2.2 },
-        roadmapOpacity: { value: 0.72 },
-        roadmapBackgroundVisibility: { value: 1.0 }
+        roadmapOpacity: { value: 0.3 },
+        roadmapBackgroundVisibility: { value: 1.0 },
+        roadmapEdgeEnhancement: { value: 0.45 },
+        roadmapEdgeDarkness: { value: 0.25 }
 
     },
     vertexShader: displayVS,
@@ -946,6 +951,7 @@ const ui = initUI({
         return result;
     },
     onClearRoadmap: () => {
+        clearCompositeRoadmapTexture();
         dsaRoadmapState.clearRoadmap();
         syncDsaRoadmapState();
     },
@@ -954,6 +960,7 @@ const ui = initUI({
     onSelectDsaSequence: sequenceId => {
         dsaRoadmapState.stopCine();
         const result = dsaRoadmapState.selectSequence(sequenceId);
+        if (result.ok) clearCompositeRoadmapTexture();
         syncDsaRoadmapState();
         return result;
     },
@@ -963,17 +970,52 @@ const ui = initUI({
             sequenceId,
             frameIndex
         );
+        if (result.ok) clearCompositeRoadmapTexture();
         syncDsaRoadmapState();
         return result;
     },
     onUseBestDsaFrame: sequenceId => {
         dsaRoadmapState.stopCine();
         const result = dsaRoadmapState.useBestFrame(sequenceId);
+        if (result.ok) clearCompositeRoadmapTexture();
+        syncDsaRoadmapState();
+        return result;
+    },
+    onBuildRoadmapRange: (sequenceId, startFrameIndex, endFrameIndex) => {
+        dsaRoadmapState.stopCine();
+        return buildDsaRangeRoadmap(
+            sequenceId,
+            startFrameIndex,
+            endFrameIndex
+        );
+    },
+    onPreviewDsaRangeFrame: (sequenceId, frameIndex) => {
+        const snapshot = dsaRoadmapState.getSnapshot();
+        if (snapshot.cineSequenceId !== Number(sequenceId)) {
+            return { ok: false, reason: '' };
+        }
+        const nowMs = performance.now();
+        if (snapshot.cinePlaying) dsaRoadmapState.pauseCine({ nowMs });
+        const result = dsaRoadmapState.seekCineFrame(frameIndex, { nowMs });
         syncDsaRoadmapState();
         return result;
     },
     onToggleDsaCine: sequenceId => {
         const result = dsaRoadmapState.toggleCine(sequenceId, {
+            nowMs: performance.now()
+        });
+        syncDsaRoadmapState();
+        return result;
+    },
+    onSeekDsaCineFrame: frameIndex => {
+        const result = dsaRoadmapState.seekCineFrame(frameIndex, {
+            nowMs: performance.now()
+        });
+        syncDsaRoadmapState();
+        return result;
+    },
+    onSetDsaCineSpeed: playbackRate => {
+        const result = dsaRoadmapState.setCinePlaybackRate(playbackRate, {
             nowMs: performance.now()
         });
         syncDsaRoadmapState();
@@ -1023,6 +1065,144 @@ function selectedDsaFrameTexture(snapshot) {
             snapshot.selectedFrameIndex
         )
     ) || null;
+}
+
+function clearCompositeRoadmapTexture() {
+    dsaCompositeRoadmapTexture?.dispose?.();
+    dsaCompositeRoadmapTexture = null;
+    dsaCompositeRoadmapKey = '';
+}
+
+function createDsaLumaTexture(redChannel, width, height, name = '') {
+    const textureFormat = renderer.capabilities.isWebGL2
+        ? THREE.RedFormat
+        : THREE.LuminanceFormat;
+    const texture = new THREE.DataTexture(
+        redChannel,
+        width,
+        height,
+        textureFormat,
+        THREE.UnsignedByteType
+    );
+    texture.minFilter = THREE.LinearFilter;
+    texture.magFilter = THREE.LinearFilter;
+    texture.wrapS = THREE.ClampToEdgeWrapping;
+    texture.wrapT = THREE.ClampToEdgeWrapping;
+    texture.generateMipmaps = false;
+    texture.flipY = false;
+    texture.colorSpace = THREE.NoColorSpace;
+    texture.name = name;
+    texture.needsUpdate = true;
+    return texture;
+}
+
+function createDsaRangeCompositeTexture(storageKeys, name) {
+    const sourceTextures = storageKeys
+        .map(storageKey => dsaSequenceFrameTextures.get(storageKey))
+        .filter(Boolean);
+    if (sourceTextures.length !== storageKeys.length || !sourceTextures.length) {
+        return null;
+    }
+    const firstImage = sourceTextures[0].image;
+    if (!firstImage?.data || !firstImage.width || !firstImage.height) return null;
+    const redChannels = [];
+    for (let textureIndex = 0; textureIndex < sourceTextures.length; textureIndex++) {
+        const image = sourceTextures[textureIndex].image;
+        if (
+            !image?.data ||
+            image.width !== firstImage.width ||
+            image.height !== firstImage.height ||
+            image.data.length !== firstImage.data.length
+        ) return null;
+        redChannels.push(image.data);
+    }
+    const composite = composeDsaFrameRangeRedChannels(redChannels);
+    if (!composite) return null;
+    return createDsaLumaTexture(
+        composite,
+        firstImage.width,
+        firstImage.height,
+        name
+    );
+}
+
+function buildDsaRangeRoadmap(sequenceId, startFrameIndex, endFrameIndex) {
+    const snapshot = dsaRoadmapState.getSnapshot();
+    const sequence = snapshot.sequences.find(candidate =>
+        candidate.id === Number(sequenceId)
+    );
+    if (!sequence?.complete || !sequence.frames.length) {
+        const result = dsaRoadmapState.selectRoadmapRange(
+            sequenceId,
+            startFrameIndex,
+            endFrameIndex
+        );
+        syncDsaRoadmapState();
+        return result;
+    }
+    const requestedStart = Number(startFrameIndex);
+    const requestedEnd = Number(endFrameIndex);
+    if (!Number.isFinite(requestedStart) || !Number.isFinite(requestedEnd)) {
+        const result = dsaRoadmapState.selectRoadmapRange(
+            sequence.id,
+            startFrameIndex,
+            endFrameIndex
+        );
+        syncDsaRoadmapState();
+        return result;
+    }
+    const lastIndex = sequence.frames.length - 1;
+    const startIndex = Math.max(0, Math.min(
+        lastIndex,
+        Math.min(Math.round(requestedStart), Math.round(requestedEnd))
+    ));
+    const endIndex = Math.max(0, Math.min(
+        lastIndex,
+        Math.max(Math.round(requestedStart), Math.round(requestedEnd))
+    ));
+    const storageKeys = sequence.frames
+        .slice(startIndex, endIndex + 1)
+        .map(frame => frame.storageKey);
+    const compositeKey = `${sequence.id}:${startIndex}:${endIndex}`;
+    if (
+        dsaCompositeRoadmapTexture &&
+        dsaCompositeRoadmapKey === compositeKey
+    ) {
+        const result = dsaRoadmapState.selectRoadmapRange(
+            sequence.id,
+            startIndex,
+            endIndex
+        );
+        syncDsaRoadmapState();
+        return result;
+    }
+    const compositeTexture = createDsaRangeCompositeTexture(
+        storageKeys,
+        `dsa-roadmap-range-${compositeKey}`
+    );
+    if (!compositeTexture) {
+        console.warn('Unable to build DSA range roadmap texture', {
+            sequenceId: sequence.id,
+            startIndex,
+            endIndex
+        });
+        return { ok: false, reason: 'The selected DSA frame range is unavailable' };
+    }
+    const result = dsaRoadmapState.selectRoadmapRange(
+        sequence.id,
+        startIndex,
+        endIndex
+    );
+    if (!result.ok) {
+        compositeTexture.dispose();
+        syncDsaRoadmapState();
+        return result;
+    }
+    clearCompositeRoadmapTexture();
+    dsaCompositeRoadmapTexture = compositeTexture;
+    dsaCompositeRoadmapKey = compositeKey;
+    syncDsaRoadmapState();
+    return result;
 }
 
 function cineDsaFrameTexture(snapshot) {
@@ -1080,8 +1260,12 @@ function syncDsaRoadmapState() {
     const snapshot = dsaRoadmapState.getSnapshot();
     pruneDsaFrameTextures(snapshot);
     const cineTexture = cineDsaFrameTexture(snapshot);
+    const selectedRoadmapTexture = snapshot.roadmapCompositeActive &&
+        dsaCompositeRoadmapTexture
+        ? dsaCompositeRoadmapTexture
+        : selectedDsaFrameTexture(snapshot);
     displayMaterial.uniforms.roadmapTexture.value =
-        selectedDsaFrameTexture(snapshot) || roadmapTarget.texture;
+        selectedRoadmapTexture || roadmapTarget.texture;
     displayMaterial.uniforms.cineTexture.value =
         cineTexture || roadmapTarget.texture;
     displayMaterial.uniforms.dsaEnabled.value = snapshot.dsaEnabled;
@@ -1115,6 +1299,7 @@ function finishDsaSequenceRecording() {
     const result = dsaRoadmapState.finishSequenceRecording({
         endedAtMs: performance.now()
     });
+    if (result.ok) clearCompositeRoadmapTexture();
     syncDsaRoadmapState();
     return result;
 }
@@ -2550,25 +2735,12 @@ function createArchivedDsaFrame() {
     for (let index = 0; index < redChannel.length; index++) {
         redChannel[index] = dsaFrameReadback[index * 4];
     }
-    const textureFormat = renderer.capabilities.isWebGL2
-        ? THREE.RedFormat
-        : THREE.LuminanceFormat;
-    const texture = new THREE.DataTexture(
+    return createDsaLumaTexture(
         redChannel,
         width,
         height,
-        textureFormat,
-        THREE.UnsignedByteType
+        'dsa-archive-frame'
     );
-    texture.minFilter = THREE.LinearFilter;
-    texture.magFilter = THREE.LinearFilter;
-    texture.wrapS = THREE.ClampToEdgeWrapping;
-    texture.wrapT = THREE.ClampToEdgeWrapping;
-    texture.generateMipmaps = false;
-    texture.flipY = false;
-    texture.colorSpace = THREE.NoColorSpace;
-    texture.needsUpdate = true;
-    return texture;
 }
 
 function projectedContrastScore() {
@@ -2626,9 +2798,10 @@ function captureDsaSequenceFrame() {
         });
     }
     if (appended.shouldStop) {
-        dsaRoadmapState.finishSequenceRecording({
+        const finished = dsaRoadmapState.finishSequenceRecording({
             endedAtMs: performance.now()
         });
+        if (finished.ok) clearCompositeRoadmapTexture();
     }
     return appended;
 }
@@ -2663,7 +2836,9 @@ function processDsaRoadmapCapture() {
                 dsaEnabled: true,
                 dsaMaskValid: true
             });
-            dsaRoadmapState.markRoadmapCaptured(revision);
+            if (dsaRoadmapState.markRoadmapCaptured(revision)) {
+                clearCompositeRoadmapTexture();
+            }
         }
         snapshot = syncDsaRoadmapState();
     }

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -47,7 +47,11 @@ export function initUI(options) {
     onSelectDsaSequence,
     onSelectDsaFrame,
     onUseBestDsaFrame,
+    onBuildRoadmapRange,
+    onPreviewDsaRangeFrame,
     onToggleDsaCine,
+    onSeekDsaCineFrame,
+    onSetDsaCineSpeed,
     onStopDsaCine,
   } = options;
 
@@ -141,13 +145,22 @@ export function initUI(options) {
   const dsaFrameSelect = document.getElementById('dsaFrameSelect');
   const useBestDsaFrameButton = document.getElementById('useBestDsaFrame');
   const dsaFrameInfoEl = document.getElementById('dsaFrameInfo');
+  const dsaRangeSliderEl = document.getElementById('dsaRangeSlider');
+  const dsaRangeStartSlider = document.getElementById('dsaRangeStart');
+  const dsaRangeEndSlider = document.getElementById('dsaRangeEnd');
+  const buildRoadmapRangeButton = document.getElementById('buildRoadmapRange');
+  const dsaRangeInfoEl = document.getElementById('dsaRangeInfo');
   const dsaSequenceGalleryEl = document.getElementById('dsaSequenceGallery');
   const dsaCineControlsEl = document.getElementById('dsaCineControls');
   const dsaCineStatusEl = document.getElementById('dsaCineStatus');
+  const dsaCineFrameSlider = document.getElementById('dsaCineFrame');
+  const dsaCineSpeedSelect = document.getElementById('dsaCineSpeed');
   const dsaCinePlayPauseButton = document.getElementById('dsaCinePlayPause');
   const dsaCineStopButton = document.getElementById('dsaCineStop');
   const roadmapOpacitySlider = document.getElementById('roadmapOpacity');
   const roadmapBackgroundSlider = document.getElementById('roadmapBackground');
+  const roadmapEdgeEnhancementSlider = document.getElementById('roadmapEdgeEnhancement');
+  const roadmapEdgeDarknessSlider = document.getElementById('roadmapEdgeDarkness');
   const dsaGainSlider = document.getElementById('dsaGain');
   const dsaRoadmapStatusEl = document.getElementById('dsaRoadmapStatus');
   const imagingModeBadgeEl = document.getElementById('imagingModeBadge');
@@ -392,6 +405,8 @@ export function initUI(options) {
     boneVisibilitySlider,
     contrastOpacitySlider,
     contrastGainSlider,
+    roadmapEdgeEnhancementSlider,
+    roadmapEdgeDarknessSlider,
     injVolumeSlider,
     injRateSlider,
     cardiacOutputSlider,
@@ -670,6 +685,28 @@ export function initUI(options) {
         parseFloat(e.target.value) / 100;
     });
   }
+  if (
+    roadmapEdgeEnhancementSlider &&
+    displayMaterial.uniforms.roadmapEdgeEnhancement
+  ) {
+    displayMaterial.uniforms.roadmapEdgeEnhancement.value =
+      parseFloat(roadmapEdgeEnhancementSlider.value) / 100;
+    roadmapEdgeEnhancementSlider.addEventListener('input', e => {
+      displayMaterial.uniforms.roadmapEdgeEnhancement.value =
+        parseFloat(e.target.value) / 100;
+    });
+  }
+  if (
+    roadmapEdgeDarknessSlider &&
+    displayMaterial.uniforms.roadmapEdgeDarkness
+  ) {
+    displayMaterial.uniforms.roadmapEdgeDarkness.value =
+      parseFloat(roadmapEdgeDarknessSlider.value) / 100;
+    roadmapEdgeDarknessSlider.addEventListener('input', e => {
+      displayMaterial.uniforms.roadmapEdgeDarkness.value =
+        parseFloat(e.target.value) / 100;
+    });
+  }
   if (dsaGainSlider && displayMaterial.uniforms.dsaGain) {
     displayMaterial.uniforms.dsaGain.value = parseFloat(dsaGainSlider.value);
     dsaGainSlider.addEventListener('input', e => {
@@ -731,6 +768,84 @@ export function initUI(options) {
     onUseBestDsaFrame?.(sequenceId);
     useBestDsaFrameButton.blur();
   });
+  let activeRoadmapRangeSignature = '';
+  const updateDsaRangeTrack = () => {
+    if (!dsaRangeSliderEl || !dsaRangeStartSlider || !dsaRangeEndSlider) return;
+    const minimum = Number(dsaRangeStartSlider.min || 0);
+    const maximum = Number(dsaRangeStartSlider.max || 0);
+    const span = Math.max(1, maximum - minimum);
+    const start = Math.min(
+      Number(dsaRangeStartSlider.value),
+      Number(dsaRangeEndSlider.value)
+    );
+    const end = Math.max(
+      Number(dsaRangeStartSlider.value),
+      Number(dsaRangeEndSlider.value)
+    );
+    dsaRangeSliderEl.style.setProperty(
+      '--range-start',
+      `${((start - minimum) / span) * 100}%`
+    );
+    dsaRangeSliderEl.style.setProperty(
+      '--range-end',
+      `${((end - minimum) / span) * 100}%`
+    );
+  };
+  const updateDsaRangeInfo = () => {
+    updateDsaRangeTrack();
+    if (!dsaRangeInfoEl) return;
+    if (
+      !dsaRangeStartSlider ||
+      !dsaRangeEndSlider ||
+      dsaRangeStartSlider.disabled
+    ) {
+      dsaRangeInfoEl.textContent = 'Select a saved angiography';
+      return;
+    }
+    const startIndex = Math.min(
+      Number(dsaRangeStartSlider.value),
+      Number(dsaRangeEndSlider.value)
+    );
+    const endIndex = Math.max(
+      Number(dsaRangeStartSlider.value),
+      Number(dsaRangeEndSlider.value)
+    );
+    const sequenceId = dsaSequenceSelect?.value || '';
+    const signature = `${sequenceId}:${startIndex}:${endIndex}`;
+    const prefix = signature === activeRoadmapRangeSignature
+      ? 'Active roadmap'
+      : 'Selected range';
+    dsaRangeInfoEl.textContent =
+      `${prefix}: frames ${startIndex + 1}–${endIndex + 1} · ${endIndex - startIndex + 1} frame${endIndex === startIndex ? '' : 's'}`;
+  };
+  const previewDsaRangeFrame = (slider, boundarySlider, isStart) => {
+    const value = Number(slider.value);
+    const boundary = Number(boundarySlider.value);
+    if (isStart && value > boundary) slider.value = boundarySlider.value;
+    if (!isStart && value < boundary) slider.value = boundarySlider.value;
+    updateDsaRangeInfo();
+    const sequenceId = Number(dsaSequenceSelect?.value);
+    if (Number.isFinite(sequenceId) && dsaSequenceSelect?.value !== '') {
+      onPreviewDsaRangeFrame?.(sequenceId, Number(slider.value));
+    }
+  };
+  dsaRangeStartSlider?.addEventListener('input', () => {
+    previewDsaRangeFrame(dsaRangeStartSlider, dsaRangeEndSlider, true);
+  });
+  dsaRangeEndSlider?.addEventListener('input', () => {
+    previewDsaRangeFrame(dsaRangeEndSlider, dsaRangeStartSlider, false);
+  });
+  buildRoadmapRangeButton?.addEventListener('click', () => {
+    const sequenceId = Number(dsaSequenceSelect?.value);
+    if (Number.isFinite(sequenceId) && dsaSequenceSelect?.value !== '') {
+      onBuildRoadmapRange?.(
+        sequenceId,
+        Number(dsaRangeStartSlider?.value || 0),
+        Number(dsaRangeEndSlider?.value || 0)
+      );
+    }
+    buildRoadmapRangeButton.blur();
+  });
   dsaSequenceGalleryEl?.addEventListener('click', event => {
     const actionButton = event.target.closest('[data-dsa-gallery-action]');
     if (!actionButton || !dsaSequenceGalleryEl.contains(actionButton)) return;
@@ -746,6 +861,12 @@ export function initUI(options) {
   dsaCinePlayPauseButton?.addEventListener('click', () => {
     onToggleDsaCine?.();
     dsaCinePlayPauseButton.blur();
+  });
+  dsaCineFrameSlider?.addEventListener('input', e => {
+    onSeekDsaCineFrame?.(Number(e.target.value));
+  });
+  dsaCineSpeedSelect?.addEventListener('change', e => {
+    onSetDsaCineSpeed?.(Number(e.target.value));
   });
   dsaCineStopButton?.addEventListener('click', () => {
     onStopDsaCine?.();
@@ -1285,6 +1406,8 @@ export function initUI(options) {
 
   let dsaSequenceOptionSignature = '';
   let dsaGallerySignature = '';
+  let dsaRangeSequenceSignature = '';
+  let previousActiveRoadmapRangeSignature = '';
 
   function updateDsaRoadmapState(state = {}) {
     const maskPending = state.maskCapturePending === true;
@@ -1401,6 +1524,51 @@ export function initUI(options) {
           ? 'Recording DSA frames…'
           : 'Hold R to record a sequence';
     }
+    const rangeSequenceSignature = selectedSequence
+      ? `${selectedSequence.id}:${selectedSequence.frames.length}`
+      : '';
+    if (rangeSequenceSignature !== dsaRangeSequenceSignature) {
+      dsaRangeSequenceSignature = rangeSequenceSignature;
+      const lastFrameIndex = Math.max(
+        0,
+        (selectedSequence?.frames.length || 1) - 1
+      );
+      for (const slider of [dsaRangeStartSlider, dsaRangeEndSlider]) {
+        if (!slider) continue;
+        slider.min = '0';
+        slider.max = String(lastFrameIndex);
+      }
+      if (dsaRangeStartSlider) dsaRangeStartSlider.value = '0';
+      if (dsaRangeEndSlider) dsaRangeEndSlider.value = String(lastFrameIndex);
+    }
+    const rangeControlsDisabled = recording || !selectedSequence;
+    if (dsaRangeStartSlider) dsaRangeStartSlider.disabled = rangeControlsDisabled;
+    if (dsaRangeEndSlider) dsaRangeEndSlider.disabled = rangeControlsDisabled;
+    dsaRangeSliderEl?.classList.toggle('disabled', rangeControlsDisabled);
+    if (buildRoadmapRangeButton) {
+      buildRoadmapRangeButton.disabled = rangeControlsDisabled;
+    }
+    const nextActiveRoadmapRangeSignature =
+      state.roadmapCompositeActive &&
+      selectedSequence?.id === state.selectedSequenceId &&
+      Number.isInteger(state.selectedRangeStartIndex) &&
+      Number.isInteger(state.selectedRangeEndIndex)
+        ? `${selectedSequence.id}:${state.selectedRangeStartIndex}:${state.selectedRangeEndIndex}`
+        : '';
+    if (
+      nextActiveRoadmapRangeSignature &&
+      nextActiveRoadmapRangeSignature !== previousActiveRoadmapRangeSignature
+    ) {
+      if (dsaRangeStartSlider) {
+        dsaRangeStartSlider.value = String(state.selectedRangeStartIndex);
+      }
+      if (dsaRangeEndSlider) {
+        dsaRangeEndSlider.value = String(state.selectedRangeEndIndex);
+      }
+    }
+    activeRoadmapRangeSignature = nextActiveRoadmapRangeSignature;
+    previousActiveRoadmapRangeSignature = nextActiveRoadmapRangeSignature;
+    updateDsaRangeInfo();
     const gallerySignature = completedSequences
       .map(sequence => [
         sequence.id,
@@ -1482,10 +1650,23 @@ export function initUI(options) {
     if (dsaCineControlsEl) dsaCineControlsEl.hidden = !cineActive;
     if (dsaCineStatusEl) {
       dsaCineStatusEl.textContent = cineActive
-        ? `CINE DSA ${cineSequence.id} · ${state.cineFrameIndex + 1}/${cineSequence.frames.length}`
+        ? `CINE DSA ${cineSequence.id} · ${state.cineFrameIndex + 1}/${cineSequence.frames.length} · ${state.cinePlaybackRate || 1}×`
         : 'CINE';
     }
+    if (dsaCineFrameSlider) {
+      dsaCineFrameSlider.disabled = !cineActive;
+      dsaCineFrameSlider.min = '0';
+      dsaCineFrameSlider.max = String(
+        Math.max(0, (cineSequence?.frames.length || 1) - 1)
+      );
+      dsaCineFrameSlider.value = String(state.cineFrameIndex || 0);
+    }
+    if (dsaCineSpeedSelect) {
+      dsaCineSpeedSelect.disabled = !cineActive;
+      dsaCineSpeedSelect.value = String(state.cinePlaybackRate || 1);
+    }
     if (dsaCinePlayPauseButton) {
+      dsaCinePlayPauseButton.disabled = !cineActive;
       dsaCinePlayPauseButton.textContent = state.cinePlaying ? 'Pause' : 'Play';
     }
     if (dsaCineStopButton) dsaCineStopButton.disabled = !cineActive;

--- a/style.css
+++ b/style.css
@@ -358,7 +358,10 @@ canvas {
 }
 
 .dsa-cine-controls {
-    flex: 0 0 auto;
+    position: absolute;
+    top: 42px;
+    left: 0;
+    width: min(610px, calc(100vw - 300px));
     min-height: 34px;
     box-sizing: border-box;
     display: flex;
@@ -376,11 +379,42 @@ canvas {
 }
 
 #dsaCineStatus {
-    min-width: 112px;
+    min-width: 126px;
     color: #dffff8;
     font: 800 10px/1.2 ui-monospace, SFMono-Regular, Menlo, monospace;
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
+}
+
+.dsa-cine-frame-control,
+.dsa-cine-speed-control {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    min-width: 0;
+    color: rgba(223, 255, 248, 0.78);
+    font-size: 9px;
+    font-weight: 750;
+    white-space: nowrap;
+}
+
+.dsa-cine-frame-control {
+    flex: 1 1 150px;
+}
+
+#dsaCineFrame {
+    min-width: 76px;
+    width: 100%;
+}
+
+#dsaCineSpeed {
+    min-height: 26px;
+    border: 1px solid rgba(146, 239, 220, 0.42);
+    border-radius: 3px;
+    background: rgba(7, 50, 47, 0.96);
+    color: #edfffb;
+    font-size: 10px;
+    font-weight: 750;
 }
 
 .dsa-cine-controls button {
@@ -1059,6 +1093,127 @@ canvas {
     font-variant-numeric: tabular-nums;
 }
 
+.dsa-roadmap-range {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: minmax(270px, 1fr) auto;
+    gap: 5px 8px;
+    align-items: end;
+    padding-top: 6px;
+    border-top: 1px solid rgba(115, 180, 255, 0.2);
+}
+
+.dsa-roadmap-range-selector {
+    display: grid;
+    gap: 3px;
+    min-width: 0;
+    color: rgba(225, 244, 255, 0.78);
+    font-size: 9px;
+    font-weight: 700;
+}
+
+.dsa-range-slider {
+    --range-start: 0%;
+    --range-end: 100%;
+    position: relative;
+    height: 22px;
+}
+
+.dsa-range-slider::before {
+    content: "";
+    position: absolute;
+    z-index: 0;
+    top: 9px;
+    right: 0;
+    left: 0;
+    height: 4px;
+    border-radius: 999px;
+    background: linear-gradient(
+        to right,
+        rgba(220, 232, 240, 0.72) 0 var(--range-start),
+        #3d92ff var(--range-start) var(--range-end),
+        rgba(220, 232, 240, 0.72) var(--range-end) 100%
+    );
+    box-shadow: inset 0 0 0 1px rgba(0, 22, 42, 0.38);
+}
+
+.dsa-range-slider input[type="range"] {
+    position: absolute;
+    z-index: 2;
+    inset: 0;
+    width: 100%;
+    height: 22px;
+    margin: 0;
+    appearance: none;
+    -webkit-appearance: none;
+    background: transparent;
+    pointer-events: none;
+}
+
+.dsa-range-slider #dsaRangeEnd {
+    z-index: 3;
+}
+
+.dsa-range-slider input[type="range"]:focus {
+    z-index: 4;
+    outline: none;
+}
+
+.dsa-range-slider input[type="range"]::-webkit-slider-runnable-track {
+    height: 4px;
+    background: transparent;
+}
+
+.dsa-range-slider input[type="range"]::-webkit-slider-thumb {
+    width: 15px;
+    height: 15px;
+    margin-top: -5.5px;
+    appearance: none;
+    -webkit-appearance: none;
+    border: 2px solid #d8edff;
+    border-radius: 50%;
+    background: #3186ef;
+    box-shadow: 0 0 0 1px rgba(0, 34, 71, 0.75);
+    cursor: ew-resize;
+    pointer-events: auto;
+}
+
+.dsa-range-slider input[type="range"]::-moz-range-track {
+    height: 4px;
+    background: transparent;
+}
+
+.dsa-range-slider input[type="range"]::-moz-range-thumb {
+    width: 12px;
+    height: 12px;
+    border: 2px solid #d8edff;
+    border-radius: 50%;
+    background: #3186ef;
+    box-shadow: 0 0 0 1px rgba(0, 34, 71, 0.75);
+    cursor: ew-resize;
+    pointer-events: auto;
+}
+
+.dsa-range-slider.disabled {
+    opacity: 0.42;
+}
+
+.dsa-range-slider.disabled input[type="range"]::-webkit-slider-thumb {
+    cursor: not-allowed;
+}
+
+.dsa-roadmap-range button {
+    padding: 4px 10px;
+}
+
+#dsaRangeInfo {
+    grid-column: 1 / -1;
+    min-height: 14px;
+    color: #ffe5a3;
+    font-size: 9px;
+    font-variant-numeric: tabular-nums;
+}
+
 .dsa-gallery-heading {
     grid-column: 1 / -1;
     display: flex;
@@ -1193,7 +1348,9 @@ canvas {
 }
 
 .dsa-roadmap-opacity,
-.dsa-roadmap-background {
+.dsa-roadmap-background,
+.dsa-roadmap-edge-enhancement,
+.dsa-roadmap-edge-darkness {
     min-width: 170px;
 }
 

--- a/tests/dsaRoadmapState.test.js
+++ b/tests/dsaRoadmapState.test.js
@@ -8,6 +8,7 @@ import {
     dsaArchiveDimensions,
     dsaScoreDimensions
 } from '../src/imaging/dsaCaptureSizing.js';
+import { composeDsaFrameRangeRedChannels } from '../src/imaging/dsaFrameComposite.js';
 
 const state = new DsaRoadmapState({
     maxSequences: 3,
@@ -80,6 +81,24 @@ assert.equal(state.getSnapshot().selectedFrameIndex, 0);
 assert.equal(state.useBestFrame(firstRecording.sequenceId).ok, true);
 assert.equal(state.getSnapshot().selectedFrameIndex, 1);
 
+// A roadmap can also combine a continuous frame range. The state normalizes
+// reversed endpoints and exposes every source texture key to the renderer.
+const rangeRoadmap = state.selectRoadmapRange(
+    firstRecording.sequenceId,
+    2,
+    0
+);
+assert.equal(rangeRoadmap.ok, true);
+assert.equal(rangeRoadmap.startFrameIndex, 0);
+assert.equal(rangeRoadmap.endFrameIndex, 2);
+assert.equal(rangeRoadmap.frameCount, 3);
+assert.deepEqual(rangeRoadmap.storageKeys, ['1:0', '1:1', '1:2']);
+snapshot = state.getSnapshot();
+assert.equal(snapshot.roadmapCompositeActive, true);
+assert.equal(snapshot.selectedFrameIndex, null);
+assert.equal(snapshot.selectedRangeStartIndex, 0);
+assert.equal(snapshot.selectedRangeEndIndex, 2);
+
 // Archived cine uses the captured frame timing, can be paused/resumed, and
 // remains independent from the frame currently selected for roadmapping.
 assert.equal(
@@ -92,12 +111,38 @@ assert.equal(cineAdvance.changed, true);
 assert.equal(state.getSnapshot().cineFrameIndex, 1);
 assert.equal(state.pauseCine({ nowMs: 1018 }).ok, true);
 assert.equal(state.getSnapshot().cinePlaying, false);
+assert.equal(state.seekCineFrame(0, { nowMs: 1500 }).ok, true);
+assert.equal(state.getSnapshot().cineFrameIndex, 0);
+assert.equal(state.setCinePlaybackRate(2, { nowMs: 1500 }).ok, true);
+assert.equal(state.getSnapshot().cinePlaybackRate, 2);
 assert.equal(state.toggleCine(firstRecording.sequenceId, { nowMs: 2000 }).ok, true);
 assert.equal(state.getSnapshot().cinePlaying, true);
-state.advanceCine({ nowMs: 2010 });
+state.advanceCine({ nowMs: 2005 });
+assert.equal(state.getSnapshot().cineFrameIndex, 1);
+assert.equal(state.seekCineFrame(2, { nowMs: 2006 }).ok, true);
 assert.equal(state.getSnapshot().cineFrameIndex, 2);
+assert.equal(state.setCinePlaybackRate(0.5, { nowMs: 2006 }).ok, true);
+assert.equal(state.getSnapshot().cinePlaybackRate, 0.5);
 assert.equal(state.stopCine().ok, true);
 assert.equal(state.getSnapshot().cineSequenceId, null);
+
+// The range compositor keeps the darkest vessel signal from every selected
+// frame, producing the temporal union used by the roadmap texture.
+assert.deepEqual(
+    [...composeDsaFrameRangeRedChannels([
+        new Uint8Array([220, 40, 220, 220]),
+        new Uint8Array([220, 220, 35, 220]),
+        new Uint8Array([220, 220, 220, 28])
+    ])],
+    [220, 40, 35, 28]
+);
+assert.equal(
+    composeDsaFrameRangeRedChannels([
+        new Uint8Array([220, 40]),
+        new Uint8Array([220])
+    ]),
+    null
+);
 
 // Sequence frames retain the full detector buffer. Only the lightweight
 // contrast-scoring pass is allowed to downsample.


### PR DESCRIPTION
## What changed

- add cine frame scrubbing, play/pause, and playback-speed controls
- build a roadmap from a selected DSA frame range using a minimum-intensity composite
- preview the active start or end frame while adjusting the range
- replace separate range sliders with one dual-handle selector
- make roadmap brightness, opacity, background, edge enhancement, and edge darkness adjustable
- default roadmap opacity to 30%

## Why

Roadmap preparation should make it easy to inspect cine frames, choose the useful acquisition interval, and create a readable overlay without obscuring live fluoroscopy.

## Validation

- `npm run test:imaging`
- `node --check src/ui/ui.js`
- `node --check src/simulator.js`
- `git diff --check`
- manual browser verification on the local Vite app, including cine pause/seek/speed, range preview, dual-handle constraints, range composition, and shader console checks

## Note

The full `npm test` suite still hits the existing performance threshold in `tests/aortaPreprocess.test.js` on this machine; the imaging tests pass.